### PR TITLE
[MAT-3798] Measure Scoring Validation

### DIFF
--- a/src/main/java/cms/gov/madie/measure/models/EnumValidator.java
+++ b/src/main/java/cms/gov/madie/measure/models/EnumValidator.java
@@ -21,7 +21,7 @@ public @interface EnumValidator {
 
   Class<? extends Enum<?>> enumClass();
 
-  String message() default "Value is not valid";
+  String message() default "Value provided is not a valid option.";
 
   Class<?>[] groups() default {};
 

--- a/src/main/java/cms/gov/madie/measure/models/Measure.java
+++ b/src/main/java/cms/gov/madie/measure/models/Measure.java
@@ -68,13 +68,13 @@ public class Measure {
   private String model;
 
   @NotBlank(
-      groups = {ValidationOrder1.class},
-      message = "Measure Scoring is required."
-  )
+      groups = {ValidationOrder5.class},
+      message = "Measure Scoring is required.")
   @EnumValidator(
       enumClass = MeasureScoring.class,
       groups = {ValidationOrder5.class})
   private String measureScoring;
+
   private MeasureMetaData measureMetaData = new MeasureMetaData();
 
   @GroupSequence({

--- a/src/main/java/cms/gov/madie/measure/models/Measure.java
+++ b/src/main/java/cms/gov/madie/measure/models/Measure.java
@@ -28,27 +28,27 @@ public class Measure {
   @Indexed(unique = true)
   @NotBlank(
       groups = {ValidationOrder1.class},
-      message = "Measure Library Name is required")
+      message = "Measure Library Name is required.")
   @Pattern(
       regexp = "^[A-Z][a-zA-Z0-9]*$",
       groups = {
         ValidationOrder2.class,
       },
-      message = "Measure Library Name is invalid")
+      message = "Measure Library Name is invalid.")
   private String cqlLibraryName;
 
   @NotBlank(
       groups = {ValidationOrder1.class},
-      message = "Measure Name is required")
+      message = "Measure Name is required.")
   @Length(
       min = 1,
       max = 500,
       groups = {ValidationOrder2.class},
-      message = "Measure Name can not be more than 500 characters")
+      message = "Measure Name can not be more than 500 characters.")
   @Pattern(
       regexp = "^[^_]+$",
       groups = {ValidationOrder3.class},
-      message = "Measure Name can not contain underscores")
+      message = "Measure Name can not contain underscores.")
   @Pattern(
       regexp = ".*[a-zA-Z]+.*",
       groups = {ValidationOrder4.class},
@@ -67,6 +67,13 @@ public class Measure {
       groups = {ValidationOrder5.class})
   private String model;
 
+  @NotBlank(
+      groups = {ValidationOrder1.class},
+      message = "Measure Scoring is required."
+  )
+  @EnumValidator(
+      enumClass = MeasureScoring.class,
+      groups = {ValidationOrder5.class})
   private String measureScoring;
   private MeasureMetaData measureMetaData = new MeasureMetaData();
 

--- a/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
+++ b/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
@@ -1,0 +1,21 @@
+package cms.gov.madie.measure.models;
+
+import java.util.EnumSet;
+
+public enum MeasureScoring {
+
+    COHORT("Cohort"),
+    CONTINUOUS_VARIABLE("Continuous Variable"),
+    PROPORTION("Proportion"),
+    RATIO("Ratio");
+
+    private final String text;
+
+    MeasureScoring(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
+++ b/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
@@ -12,7 +12,8 @@ public enum MeasureScoring {
     this.text = text;
   }
 
-  public String getText() {
-    return text;
+  @Override
+  public String toString() {
+    return this.text;
   }
 }

--- a/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
+++ b/src/main/java/cms/gov/madie/measure/models/MeasureScoring.java
@@ -1,21 +1,18 @@
 package cms.gov.madie.measure.models;
 
-import java.util.EnumSet;
-
 public enum MeasureScoring {
+  COHORT("Cohort"),
+  CONTINUOUS_VARIABLE("Continuous Variable"),
+  PROPORTION("Proportion"),
+  RATIO("Ratio");
 
-    COHORT("Cohort"),
-    CONTINUOUS_VARIABLE("Continuous Variable"),
-    PROPORTION("Proportion"),
-    RATIO("Ratio");
+  private final String text;
 
-    private final String text;
+  MeasureScoring(String text) {
+    this.text = text;
+  }
 
-    MeasureScoring(String text) {
-        this.text = text;
-    }
-
-    public String getText() {
-        return text;
-    }
+  public String getText() {
+    return text;
+  }
 }

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -79,7 +79,7 @@ public class MeasureController {
     if (StringUtils.isNotEmpty(cqlLibraryName)
         && repository.findByCqlLibraryName(cqlLibraryName).isPresent()) {
       throw new DuplicateKeyException(
-          "cqlLibraryName", "CQL library with given name already exists");
+          "cqlLibraryName", "CQL library with given name already exists.");
     }
   }
 }

--- a/src/test/java/cms/gov/madie/measure/model/MeasureSerializationTest.java
+++ b/src/test/java/cms/gov/madie/measure/model/MeasureSerializationTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import cms.gov.madie.measure.models.Measure;
+import cms.gov.madie.measure.models.MeasureScoring;
 
 class MeasureSerializationTest {
 
@@ -32,7 +33,7 @@ class MeasureSerializationTest {
             + "    \"lastModifiedAt\": null,\n"
             + "    \"lastModifiedBy\": null,\n"
             + "    \"model\": null,\n"
-            + "    \"measureScoring\": \"Cohort\",\n"
+            + "    \"measureScoring\": \"COHORT\",\n"
             + "    \"measureMetaData\": {\n"
             + "        \"measureSteward\": \"Bill\"\n"
             + "    }\n"
@@ -41,7 +42,7 @@ class MeasureSerializationTest {
     Measure measure;
     try {
       measure = objectMapper.readValue(measureString, Measure.class);
-      assertEquals(measure.getMeasureScoring(), "Cohort");
+      assertEquals(measure.getMeasureScoring(), MeasureScoring.COHORT.toString());
     } catch (JsonProcessingException e) {
       fail(e);
     }

--- a/src/test/java/cms/gov/madie/measure/model/MeasureSerializationTest.java
+++ b/src/test/java/cms/gov/madie/measure/model/MeasureSerializationTest.java
@@ -33,7 +33,7 @@ class MeasureSerializationTest {
             + "    \"lastModifiedAt\": null,\n"
             + "    \"lastModifiedBy\": null,\n"
             + "    \"model\": null,\n"
-            + "    \"measureScoring\": \"COHORT\",\n"
+            + "    \"measureScoring\": \"Cohort\",\n"
             + "    \"measureMetaData\": {\n"
             + "        \"measureSteward\": \"Bill\"\n"
             + "    }\n"

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
@@ -3,7 +3,6 @@ package cms.gov.madie.measure.resources;
 import java.util.Optional;
 
 import cms.gov.madie.measure.models.MeasureScoring;
-import cms.gov.madie.measure.models.ModelType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -58,8 +57,8 @@ public class MeasureControllerMvcTest {
     when(measureRepository.save(any(Measure.class))).thenReturn(mock(Measure.class));
 
     final String measureAsJson =
-        "{\"id\": \"%s\", \"measureName\": \"%s\", \"cqlLibraryName\":\"%s\", \"measureMetaData\": { \"measureSteward\" : \"%s\"}, \"model\":\"%s\" }"
-            .formatted(measureId, measureName, libName, steward, model);
+        "{\"id\": \"%s\", \"measureName\": \"%s\", \"cqlLibraryName\":\"%s\", \"measureMetaData\": { \"measureSteward\" : \"%s\"}, \"model\":\"%s\", \"measureScoring\":\"%s\" }"
+            .formatted(measureId, measureName, libName, steward, model, scoring);
     mockMvc
         .perform(
             put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -83,7 +82,7 @@ public class MeasureControllerMvcTest {
         .perform(
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required"));
+        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -94,7 +93,7 @@ public class MeasureControllerMvcTest {
         .perform(
             put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required"));
+        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -105,7 +104,7 @@ public class MeasureControllerMvcTest {
         .perform(
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required"));
+        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -116,7 +115,7 @@ public class MeasureControllerMvcTest {
         .perform(
             put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required"));
+        .andExpect(jsonPath("$.validationErrors.measureName").value("Measure Name is required."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -129,7 +128,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.measureName")
-                .value("Measure Name can not contain underscores"));
+                .value("Measure Name can not contain underscores."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -142,7 +141,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.measureName")
-                .value("Measure Name can not contain underscores"));
+                .value("Measure Name can not contain underscores."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -158,7 +157,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.measureName")
-                .value("Measure Name can not be more than 500 characters"));
+                .value("Measure Name can not be more than 500 characters."));
   }
 
   @Test
@@ -172,7 +171,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.measureName")
-                .value("Measure Name can not be more than 500 characters"));
+                .value("Measure Name can not be more than 500 characters."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -184,10 +183,11 @@ public class MeasureControllerMvcTest {
     String measureName = "SavedMeasure";
     String libraryName = "Lib1";
     String model = "QI-Core";
-    String scoring = "PROPORTION";
+    String scoring = MeasureScoring.PROPORTION.toString();
     saved.setMeasureName(measureName);
     saved.setCqlLibraryName(libraryName);
     saved.setModel(model);
+    saved.setMeasureScoring(scoring);
     when(measureRepository.findByCqlLibraryName(eq(libraryName))).thenReturn(Optional.empty());
     when(measureRepository.save(any(Measure.class))).thenReturn(saved);
 
@@ -224,13 +224,15 @@ public class MeasureControllerMvcTest {
     existing.setCqlLibraryName(cqlLibraryName);
     String model = "QI-Core";
     existing.setModel(model);
+    String scoring = MeasureScoring.PROPORTION.toString();
+    existing.setMeasureScoring(scoring);
 
     when(measureRepository.findByCqlLibraryName(eq(cqlLibraryName)))
         .thenReturn(Optional.of(existing));
 
     final String newMeasureAsJson =
-        "{\"measureName\": \"NewMeasure\", \"cqlLibraryName\": \"%s\",\"model\":\"%s\"}"
-            .formatted(cqlLibraryName, model);
+        "{\"measureName\": \"NewMeasure\", \"cqlLibraryName\": \"%s\",\"model\":\"%s\",\"measureScoring\":\"%s\"}"
+            .formatted(cqlLibraryName, model, scoring);
     mockMvc
         .perform(
             post("/measure")
@@ -239,7 +241,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.cqlLibraryName")
-                .value("CQL library with given name already exists"));
+                .value("CQL library with given name already exists."));
 
     verify(measureRepository, times(1)).findByCqlLibraryName(eq(cqlLibraryName));
     verifyNoMoreInteractions(measureRepository);
@@ -252,6 +254,7 @@ public class MeasureControllerMvcTest {
     priorMeasure.setMeasureName("TestMeasure");
     priorMeasure.setCqlLibraryName("TestMeasureLibrary");
     priorMeasure.setModel("QI-Core");
+    priorMeasure.setMeasureScoring(MeasureScoring.RATIO.toString());
     when(measureRepository.findById(eq(priorMeasure.getId())))
         .thenReturn(Optional.of(priorMeasure));
 
@@ -263,12 +266,13 @@ public class MeasureControllerMvcTest {
         .thenReturn(Optional.of(existingMeasure));
 
     final String updatedMeasureAsJson =
-        "{\"id\": \"%s\",\"measureName\": \"%s\", \"cqlLibraryName\": \"%s\", \"model\":\"%s\"}"
+        "{\"id\": \"%s\",\"measureName\": \"%s\", \"cqlLibraryName\": \"%s\", \"model\":\"%s\", \"measureScoring\":\"%s\"}"
             .formatted(
                 priorMeasure.getId(),
                 priorMeasure.getMeasureName(),
                 existingMeasure.getCqlLibraryName(),
-                priorMeasure.getModel());
+                priorMeasure.getModel(),
+                priorMeasure.getMeasureScoring());
     mockMvc
         .perform(
             put("/measure")
@@ -277,7 +281,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.cqlLibraryName")
-                .value("CQL library with given name already exists"));
+                .value("CQL library with given name already exists."));
 
     verify(measureRepository, times(1)).findById(eq(priorMeasure.getId()));
     verify(measureRepository, times(1))
@@ -294,7 +298,7 @@ public class MeasureControllerMvcTest {
         .andExpect(status().isBadRequest())
         .andExpect(
             jsonPath("$.validationErrors.measureName")
-                .value("Measure Name can not contain underscores"));
+                .value("Measure Name can not contain underscores."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -306,7 +310,8 @@ public class MeasureControllerMvcTest {
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
         .andExpect(
-            jsonPath("$.validationErrors.cqlLibraryName").value("Measure Library Name is invalid"));
+            jsonPath("$.validationErrors.cqlLibraryName")
+                .value("Measure Library Name is invalid."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -318,7 +323,8 @@ public class MeasureControllerMvcTest {
             put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
         .andExpect(
-            jsonPath("$.validationErrors.cqlLibraryName").value("Measure Library Name is invalid"));
+            jsonPath("$.validationErrors.cqlLibraryName")
+                .value("Measure Library Name is invalid."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -330,7 +336,8 @@ public class MeasureControllerMvcTest {
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
         .andExpect(
-            jsonPath("$.validationErrors.cqlLibraryName").value("Measure Library Name is invalid"));
+            jsonPath("$.validationErrors.cqlLibraryName")
+                .value("Measure Library Name is invalid."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -342,7 +349,8 @@ public class MeasureControllerMvcTest {
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
         .andExpect(
-            jsonPath("$.validationErrors.cqlLibraryName").value("Measure Library Name is invalid"));
+            jsonPath("$.validationErrors.cqlLibraryName")
+                .value("Measure Library Name is invalid."));
     verifyNoInteractions(measureRepository);
   }
 
@@ -358,13 +366,15 @@ public class MeasureControllerMvcTest {
     saved.setCqlLibraryName(libraryName);
     String model = "QI-Core";
     saved.setModel(model);
+    String scoring = MeasureScoring.CONTINUOUS_VARIABLE.toString();
+    saved.setMeasureScoring(scoring);
 
     when(measureRepository.findByCqlLibraryName(eq(libraryName))).thenReturn(Optional.empty());
     when(measureRepository.save(any(Measure.class))).thenReturn(saved);
 
     final String measureAsJson =
-        "{ \"measureName\":\"%s\", \"cqlLibraryName\":\"%s\", \"model\":\"%s\" }"
-            .formatted(measureName, libraryName, model);
+        "{ \"measureName\":\"%s\", \"cqlLibraryName\":\"%s\", \"model\":\"%s\", \"measureScoring\":\"%s\" }"
+            .formatted(measureName, libraryName, model, scoring);
     mockMvc
         .perform(
             post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -381,7 +391,7 @@ public class MeasureControllerMvcTest {
 
   @Test
   public void
-  testUpdateMeasurePassesIfCqlLibraryNameStartsWithCapitalCharAndFollowedByAlphaNumeric()
+      testUpdateMeasurePassesIfCqlLibraryNameStartsWithCapitalCharAndFollowedByAlphaNumeric()
           throws Exception {
     String measureId = "id123";
     Measure saved = new Measure();
@@ -391,18 +401,21 @@ public class MeasureControllerMvcTest {
     saved.setMeasureName(measureName);
     saved.setCqlLibraryName(libraryName);
     String model = "QI-Core";
+    saved.setModel(model);
+    String scoring = MeasureScoring.CONTINUOUS_VARIABLE.toString();
+    saved.setMeasureScoring(scoring);
 
     when(measureRepository.findById(eq(measureId))).thenReturn(Optional.of(saved));
     when(measureRepository.save(any(Measure.class))).thenReturn(saved);
 
     final String measureAsJson =
-            "{ \"id\": \"%s\", \"measureName\":\"%s\", \"cqlLibraryName\":\"%s\", \"model\":\"%s\"}"
-                    .formatted(measureId, measureName, libraryName, model);
+        "{ \"id\": \"%s\", \"measureName\":\"%s\", \"cqlLibraryName\":\"%s\", \"model\":\"%s\", \"measureScoring\":\"%s\"}"
+            .formatted(measureId, measureName, libraryName, model, scoring);
     mockMvc
-            .perform(
-                    put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk())
-            .andExpect(content().string("Measure updated successfully."));
+        .perform(
+            put("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Measure updated successfully."));
 
     verify(measureRepository, times(1)).findById(eq(measureId));
     verify(measureRepository, times(1)).save(measureArgumentCaptor.capture());
@@ -426,14 +439,14 @@ public class MeasureControllerMvcTest {
   @Test
   public void testNewMeasureFailsWithInvalidMeasureScoringType() throws Exception {
     final String measureAsJson =
-            "{ \"measureName\":\"TestName\", \"cqlLibraryName\":\"TEST1\", \"model\":\"QI-Core\", \"measureScoring\":\"Test\" }";
+        "{ \"measureName\":\"TestName\", \"cqlLibraryName\":\"TEST1\", \"model\":\"QI-Core\", \"measureScoring\":\"Test\" }";
     mockMvc
-            .perform(
-                    post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest())
-            .andExpect(
-                    jsonPath("$.validationErrors.model")
-                            .value("Value provided is not a valid option."));
+        .perform(
+            post("/measure").content(measureAsJson).contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.validationErrors.measureScoring")
+                .value("Value provided is not a valid option."));
     verifyNoInteractions(measureRepository);
   }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3798](https://jira.cms.gov/browse/MAT-3798)
(Optional) Related Tickets:

### Summary
#### Validate Measure Scoring on measure create/update
Binding the permissible values of measure scoring to an enum. @sb-cecilialiu added an enum validator annotation that compares the de-serialized String against the values of the specified enum. The serialized value of the enum can be obtained using the built-in `toString()`.

- Run measure scoring validators after other validations to collect all issues
- Add periods to error messages.
- Add measuresScoring to test data.
- Add `getText()` method to retrieve the human friendly text representation of the measure scoring enum.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
