### PR TITLE
Feature/mat 3817 set measure created user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,12 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
         <exclusion>
-          <artifactId>spring-boot-starter-logging</artifactId>
-          <groupId>org.springframework.boot</groupId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/cms/gov/madie/measure/models/Measure.java
+++ b/src/main/java/cms/gov/madie/measure/models/Measure.java
@@ -1,6 +1,6 @@
 package cms.gov.madie.measure.models;
 
-import java.util.Date;
+import java.time.Instant;
 
 import javax.validation.GroupSequence;
 import javax.validation.constraints.NotBlank;
@@ -56,9 +56,9 @@ public class Measure {
   private String measureName;
 
   private String cql;
-  private Date createdAt;
+  private Instant createdAt;
   private String createdBy;
-  private Date lastModifiedAt;
+  private Instant lastModifiedAt;
   private String lastModifiedBy;
 
   @EnumValidator(

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
@@ -261,6 +261,10 @@ public class MeasureControllerMvcTest {
     assertEquals(libraryName, savedMeasure.getCqlLibraryName());
     assertEquals(model, savedMeasure.getModel());
     assertEquals(scoring, savedMeasure.getMeasureScoring());
+    assertEquals(TEST_USER_ID, savedMeasure.getCreatedBy());
+    assertEquals(TEST_USER_ID, savedMeasure.getLastModifiedBy());
+    assertNotNull(savedMeasure.getCreatedAt());
+    assertNotNull(savedMeasure.getLastModifiedAt());
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -45,7 +45,7 @@ class MeasureControllerTest {
     Mockito.doReturn(measure).when(repository).save(ArgumentMatchers.any());
 
     Measure measures = new Measure();
-    Principal principal = Mockito.mock(Principal.class);
+    Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn("test.user");
 
     ResponseEntity<Measure> response = controller.addMeasure(measures, principal);

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -1,8 +1,12 @@
 package cms.gov.madie.measure.resources;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
 
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -11,10 +15,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
@@ -40,12 +41,22 @@ class MeasureControllerTest {
 
   @Test
   void saveMeasure() {
+    ArgumentCaptor<Measure> saveMeasureArgCaptor = ArgumentCaptor.forClass(Measure.class);
     Mockito.doReturn(measure).when(repository).save(ArgumentMatchers.any());
 
     Measure measures = new Measure();
+    Principal principal = Mockito.mock(Principal.class);
+    when(principal.getName()).thenReturn("test.user");
 
-    ResponseEntity<Measure> response = controller.addMeasure(measures);
+    ResponseEntity<Measure> response = controller.addMeasure(measures, principal);
     assertEquals("IDIDID", response.getBody().getMeasureSetId());
+
+    verify(repository, times(1)).save(saveMeasureArgCaptor.capture());
+    Measure savedMeasure = saveMeasureArgCaptor.getValue();
+    assertThat(savedMeasure.getCreatedBy(), is(equalTo("test.user")));
+    assertThat(savedMeasure.getLastModifiedBy(), is(equalTo("test.user")));
+    assertThat(savedMeasure.getCreatedAt(), is(notNullValue()));
+    assertThat(savedMeasure.getLastModifiedAt(), is(notNullValue()));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3817](https://jira.cms.gov/browse/MAT-3817)
(Optional) Related Tickets:

### Summary

Saving user from access token onto the createdBy and lastModifiedBy for create new measure.
Switched from java.util.Date to java.time.Instant for better timezone support.
Setting the createdAt and lastModifiedAt for create new measure.
Update pom to include spring-boot-starter-logging but still exclude log4j.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
