### PR TITLE
MAT:3974: Update utils to prevent trimming additional whitespace to preserve user input

### DIFF
--- a/src/main/java/cms/gov/madie/measure/utils/UserInputSanitizeUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/UserInputSanitizeUtil.java
@@ -2,6 +2,7 @@ package cms.gov.madie.measure.utils;
 
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Safelist;
+import org.jsoup.nodes.Document;
 
 import io.micrometer.core.instrument.util.StringUtils;
 
@@ -10,7 +11,9 @@ public class UserInputSanitizeUtil {
   public static String sanitizeUserInput(String input) {
     String sanitized = input;
     if (StringUtils.isNotBlank(input)) {
-      sanitized = Jsoup.clean(input, Safelist.basic());
+      sanitized =
+          Jsoup.clean(
+              input, "", Safelist.basic(), new Document.OutputSettings().prettyPrint(false));
       if (StringUtils.isNotBlank(sanitized)) {
         sanitized =
             sanitized.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&amp;", "&");


### PR DESCRIPTION

## MADiE PR

Jira Ticket: [MAT-3974](https://jira.cms.gov/browse/MAT-3974)
(Optional) Related Tickets:
[MAT-3960](https://jira.cms.gov/browse/MAT-3960)

### Summary
This PR removes the pretty print option for jsoup that was responsible for cleaning out additional whitespace without regression affecting 3960 for expected output
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/84744653/156422776-c531fa77-2f49-4043-b601-a0b278a10e3c.png">


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
