### PR TITLE
Use configured jdk version with maven pmd plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
           </execution>
         </executions>
         <configuration>
-          <targetJdk>1.6</targetJdk>
+          <targetJdk>${java.version}</targetJdk>
         </configuration>
       </plugin>
 
@@ -274,7 +274,6 @@
         <version>3.14.0</version>
         <configuration>
           <language>java</language>
-
           <targetJdk>${java.version}</targetJdk>
         </configuration>
       </plugin>


### PR DESCRIPTION
## MADiE PR

### Summary
PMD Plugin was generating errors in the output log due to targeting jdk version <1.8. Update to use the configured jdk version (currently 16) instead of a hardcoding.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
