### PR TITLE
Updating all test cases populations based on measure group populations

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/MeasureRepository.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/MeasureRepository.java
@@ -21,4 +21,7 @@ public interface MeasureRepository extends MongoRepository<Measure, String> {
 
   @Query(value = "{_id: ?0}", fields = "{'testCases.series': 1, _id: 0}")
   Optional<Measure> findAllTestCaseSeriesByMeasureId(String measureId);
+
+  @Query(value = "{'groups._id': ?0}")
+  Optional<Measure> findGroupById(String groupId);
 }

--- a/src/test/java/cms/gov/madie/measure/validations/ScoringPopulationValidatorTest.java
+++ b/src/test/java/cms/gov/madie/measure/validations/ScoringPopulationValidatorTest.java
@@ -1,23 +1,69 @@
 package cms.gov.madie.measure.validations;
 
+import cms.gov.madie.measure.models.Group;
+import cms.gov.madie.measure.models.Measure;
 import cms.gov.madie.measure.models.MeasurePopulation;
 import cms.gov.madie.measure.models.MeasureScoring;
 import cms.gov.madie.measure.models.TestCaseGroupPopulation;
 import cms.gov.madie.measure.models.TestCasePopulationValue;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.validation.ConstraintValidatorContext;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(SpringExtension.class)
 class ScoringPopulationValidatorTest {
 
   @Mock private ConstraintValidatorContext validatorContext;
+  @Mock private MeasureRepository measureRepository;
+  private final ScoringPopulationValidator validator = new ScoringPopulationValidator();
 
-  private ScoringPopulationValidator validator = new ScoringPopulationValidator();
+  private Measure measure;
+
+  @BeforeEach
+  public void setUp() {
+    ReflectionTestUtils.setField(validator, "measureRepository", measureRepository);
+
+    Group group1 =
+        Group.builder()
+            .id("GroupId")
+            .scoring("Cohort")
+            .population(Map.of(MeasurePopulation.INITIAL_POPULATION, "Initial Population"))
+            .groupDescription("Description")
+            .build();
+    List<Group> groups = new ArrayList<>();
+    groups.add(group1);
+    measure =
+        Measure.builder()
+            .active(true)
+            .id("xyz-p13r-13ert")
+            .cql("test cql")
+            .measureScoring("Cohort")
+            .measureSetId("IDIDID")
+            .measureName("MSR01")
+            .version("0.001")
+            .groups(groups)
+            .createdAt(Instant.now())
+            .createdBy("test user")
+            .lastModifiedAt(Instant.now())
+            .lastModifiedBy("test user")
+            .build();
+  }
 
   @Test
   public void testValidatorReturnsTrueForNull() {
@@ -27,60 +73,83 @@ class ScoringPopulationValidatorTest {
 
   @Test
   public void testValidatorReturnsFalseForMissingScoring() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(null);
-    groupPopulation.setPopulationValues(
-        List.of(
-            TestCasePopulationValue.builder().name(MeasurePopulation.INITIAL_POPULATION).build()));
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .scoring(null)
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder()
+                        .name(MeasurePopulation.INITIAL_POPULATION)
+                        .build()))
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertFalse(output);
   }
 
   @Test
   public void testValidatorReturnsFalseForNullPopulationsList() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(MeasureScoring.COHORT.toString());
-    groupPopulation.setPopulationValues(null);
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .populationValues(null)
+            .scoring(MeasureScoring.COHORT.toString())
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertFalse(output);
   }
 
   @Test
   public void testValidatorReturnsFalseForEmptyPopulationsList() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(MeasureScoring.COHORT.toString());
-    groupPopulation.setPopulationValues(List.of());
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .populationValues(List.of())
+            .scoring(MeasureScoring.COHORT.toString())
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertFalse(output);
   }
 
   @Test
   public void testValidatorReturnsFalseForMissingPopulation() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(MeasureScoring.COHORT.toString());
-    groupPopulation.setPopulationValues(List.of(TestCasePopulationValue.builder().build()));
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    when(measureRepository.findGroupById(anyString())).thenReturn(Optional.of(measure));
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .groupId("GroupId")
+            .populationValues(List.of(TestCasePopulationValue.builder().build()))
+            .scoring(MeasureScoring.COHORT.toString())
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertFalse(output);
   }
 
   @Test
   public void testValidatorReturnsFalseForIncorrectPopulation() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(MeasureScoring.COHORT.toString());
-    groupPopulation.setPopulationValues(
-        List.of(TestCasePopulationValue.builder().name(MeasurePopulation.DENOMINATOR).build()));
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    when(measureRepository.findGroupById(anyString())).thenReturn(Optional.of(measure));
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .groupId("GroupId")
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().name(MeasurePopulation.DENOMINATOR).build()))
+            .scoring(MeasureScoring.COHORT.toString())
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertFalse(output);
   }
 
   @Test
   public void testValidatorReturnsTrueForCorrectPopulation() {
-    TestCaseGroupPopulation groupPopulation = new TestCaseGroupPopulation();
-    groupPopulation.setScoring(MeasureScoring.COHORT.toString());
-    groupPopulation.setPopulationValues(
-        List.of(
-            TestCasePopulationValue.builder().name(MeasurePopulation.INITIAL_POPULATION).build()));
-    boolean output = validator.isValid(groupPopulation, validatorContext);
+    when(measureRepository.findGroupById(anyString())).thenReturn(Optional.of(measure));
+    var testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder()
+            .groupId("GroupId")
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder()
+                        .name(MeasurePopulation.INITIAL_POPULATION)
+                        .build()))
+            .scoring(MeasureScoring.COHORT.toString())
+            .build();
+    boolean output = validator.isValid(testCaseGroupPopulation, validatorContext);
     assertTrue(output);
   }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4133](https://jira.cms.gov/browse/MAT-4133)
(Optional) Related Tickets:

### Summary
1. When a group is updated by adding or removing a group population or by updating the scoring, then all test cases are updated with the new populations and all its values are reset.
2. A future story will handle not reset the existing valid populations, instead add/delete as per group population changes.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
