### PR TITLE
Work with any result type when determining definition return types

### DIFF
--- a/src/main/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidator.java
+++ b/src/main/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidator.java
@@ -74,23 +74,20 @@ public class CqlDefinitionReturnTypeValidator {
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode rootNode = objectMapper.readTree(elmJson);
     ArrayNode allDefinitions = (ArrayNode) rootNode.get("library").get("statements").get("def");
-    Iterator<JsonNode> nodeIterator = allDefinitions.iterator();
-    while (nodeIterator.hasNext()) {
-      JsonNode node = nodeIterator.next();
+    for (JsonNode node : allDefinitions) {
       if (node.get("resultTypeName") != null) {
         String dataType = node.get("resultTypeName").asText();
         returnTypes.put(node.get("name").asText(), dataType.split("}")[1]);
       } else if (node.get("resultTypeSpecifier") != null) {
-        String type = node.get("resultTypeSpecifier").get("elementType").get("type").asText();
-        if ("NamedTypeSpecifier".equals(type)) {
-          String dataType = node.get("resultTypeSpecifier").get("elementType").get("name").asText();
-          returnTypes.put(node.get("name").asText(), dataType.split("}")[1]);
-        } else {
-          returnTypes.put(node.get("name").asText(), "NA");
+        Iterator<JsonNode> typeSpecifierIterator = node.get("resultTypeSpecifier").elements();
+        while (typeSpecifierIterator.hasNext()) {
+          JsonNode current = typeSpecifierIterator.next();
+          if (current.has("type") && current.get("type").asText().equals("NamedTypeSpecifier")) {
+            returnTypes.put(node.get("name").asText(), current.get("name").asText().split("}")[1]);
+          }
         }
-      } else {
-        returnTypes.put(node.get("name").asText(), "NA");
       }
+      returnTypes.putIfAbsent(node.get("name").asText(), "NA");
     }
     return returnTypes;
   }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5136](https://jira.cms.gov/browse/MAT-5136)
(Optional) Related Tickets:

### Summary

During Return Type determination, MADiE was only accounting for one of the result types, `elementType`. Modified logic to ignore the specific type and make determination based on content: containing a `name` property and a `type` property set to `Named
TypeSpecifier`.

Example non-`elementType` return info:
```
"resultTypeSpecifier": {
  "type": "IntervalTypeSpecifier",
  "pointType": {
    "name": "{urn:hl7-org:elm-types:r1}DateTime",
    "type": "NamedTypeSpecifier"
  }
}
```

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
