### PR TITLE
MAT-5306: block changes when measure is not in draft status

### DIFF
--- a/src/main/java/cms/gov/madie/measure/exceptions/InvalidDraftStatusException.java
+++ b/src/main/java/cms/gov/madie/measure/exceptions/InvalidDraftStatusException.java
@@ -1,0 +1,12 @@
+package cms.gov.madie.measure.exceptions;
+
+public class InvalidDraftStatusException extends RuntimeException {
+
+  private static final String MESSAGE =
+      "Response could not be completed for measure with ID %s, since the measure is not in a draft"
+          + " status";
+
+  public InvalidDraftStatusException(String id) {
+    super(String.format(MESSAGE, id));
+  }
+}

--- a/src/main/java/cms/gov/madie/measure/resources/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ErrorHandlingControllerAdvice.java
@@ -99,7 +99,8 @@ public class ErrorHandlingControllerAdvice {
 
   @ExceptionHandler({
     InvalidResourceBundleStateException.class,
-    CqlElmTranslationErrorException.class
+    CqlElmTranslationErrorException.class,
+    InvalidDraftStatusException.class
   })
   @ResponseStatus(HttpStatus.CONFLICT)
   @ResponseBody

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.resources;
 
+import cms.gov.madie.measure.exceptions.InvalidDraftStatusException;
 import cms.gov.madie.measure.utils.ControllerUtil;
 import gov.cms.madie.models.access.RoleEnum;
 
@@ -135,6 +136,10 @@ public class MeasureController {
         log.info("got username [{}] vs createdBy: [{}]", username, existingMeasure.getCreatedBy());
         // either owner or shared-with role
         ControllerUtil.verifyAuthorization(username, existingMeasure);
+
+        if (!existingMeasure.getMeasureMetaData().isDraft()) {
+          throw new InvalidDraftStatusException(measure.getId());
+        }
 
         // no user can update a soft-deleted measure
         if (!existingMeasure.isActive()) {

--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.exceptions.InvalidDraftStatusException;
 import cms.gov.madie.measure.exceptions.InvalidIdException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
@@ -46,6 +47,9 @@ public class GroupService {
     Measure measure = measureRepository.findById(measureId).orElse(null);
     if (measure == null) {
       throw new ResourceNotFoundException("Measure", measureId);
+    }
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
     }
     try {
       new CqlDefinitionReturnTypeValidator()
@@ -142,6 +146,10 @@ public class GroupService {
     Measure measure = measureRepository.findById(measureId).orElse(null);
     if (measure == null) {
       throw new ResourceNotFoundException("Measure", measureId);
+    }
+
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
     }
 
     if (!username.equalsIgnoreCase(measure.getCreatedBy())

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -1,6 +1,7 @@
 package cms.gov.madie.measure.services;
 
 import cms.gov.madie.measure.HapiFhirConfig;
+import cms.gov.madie.measure.exceptions.InvalidDraftStatusException;
 import cms.gov.madie.measure.exceptions.InvalidIdException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
@@ -67,6 +68,11 @@ public class TestCaseService {
   public TestCase persistTestCase(
       TestCase testCase, String measureId, String username, String accessToken) {
     final Measure measure = findMeasureById(measureId);
+
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
+    }
+
     TestCase enrichedTestCase = enrichNewTestCase(testCase, username);
     enrichedTestCase = validateTestCaseAsResource(enrichedTestCase, accessToken);
     if (measure.getTestCases() == null) {
@@ -93,6 +99,11 @@ public class TestCaseService {
       return newTestCases;
     }
     final Measure measure = findMeasureById(measureId);
+
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
+    }
+
     List<TestCase> enrichedTestCases = new ArrayList<>(newTestCases.size());
     for (TestCase testCase : newTestCases) {
       TestCase enriched = enrichNewTestCase(testCase, username);
@@ -133,6 +144,11 @@ public class TestCaseService {
   public TestCase updateTestCase(
       TestCase testCase, String measureId, String username, String accessToken) {
     Measure measure = findMeasureById(measureId);
+
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
+    }
+
     if (measure.getTestCases() == null) {
       measure.setTestCases(new ArrayList<>());
     }
@@ -209,6 +225,11 @@ public class TestCaseService {
     }
 
     Measure measure = findMeasureById(measureId);
+
+    if (!measure.getMeasureMetaData().isDraft()) {
+      throw new InvalidDraftStatusException(measure.getId());
+    }
+
     if (!hasPermissionToDelete(username, measure)) {
       log.info(
           "User [{}] is not authorized to delete the test case with ID [{}] from measure [{}]",

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -185,6 +185,7 @@ class MeasureControllerTest {
     metaData.setCopyright("TestCopyright");
     metaData.setDisclaimer("TestDisclaimer");
     metaData.setRationale("TestRationale");
+    metaData.setDraft(true);
     measure.setMeasureMetaData(metaData);
     measure.setMeasurementPeriodStart(new Date("12/02/2020"));
     measure.setMeasurementPeriodEnd(new Date("12/02/2021"));
@@ -248,6 +249,7 @@ class MeasureControllerTest {
     metaData.setCopyright("TestCopyright");
     metaData.setDisclaimer("TestDisclaimer");
     metaData.setRationale("TestRationale");
+    metaData.setDraft(true);
     measure.setMeasureMetaData(metaData);
     measure.setMeasurementPeriodStart(new Date("12/02/2020"));
     measure.setMeasurementPeriodEnd(new Date("12/02/2021"));
@@ -341,6 +343,7 @@ class MeasureControllerTest {
     measure.setCreatedBy("validuser@gmail.com");
     measure.setActive(false);
     measure.setAcls(null);
+    measure.setMeasureMetaData(MeasureMetaData.builder().draft(true).build());
     when(repository.findById(anyString())).thenReturn(Optional.of(measure));
 
     var testMeasure = new Measure();
@@ -381,6 +384,7 @@ class MeasureControllerTest {
     when(principal.getName()).thenReturn("sharedUser@gmail.com");
     measure.setCreatedBy("MSR01");
     measure.setActive(true);
+    measure.setMeasureMetaData(MeasureMetaData.builder().draft(true).build());
     AclSpecification acl = new AclSpecification();
     acl.setUserId("sharedUser@gmail.com");
     acl.setRoles(List.of(RoleEnum.SHARED_WITH));
@@ -399,6 +403,31 @@ class MeasureControllerTest {
         .checkDeletionCredentials(anyString(), anyString());
     assertThrows(
         InvalidDeletionCredentialsException.class,
+        () -> controller.updateMeasure("testid", testMeasure, principal, "Bearer TOKEN"));
+  }
+
+  @Test
+  void testUpdateMeasureReturnsInvalidDraftStatusException() {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn("sharedUser@gmail.com");
+    measure.setCreatedBy("MSR01");
+    measure.setActive(true);
+    measure.setMeasureMetaData(MeasureMetaData.builder().draft(false).build());
+    AclSpecification acl = new AclSpecification();
+    acl.setUserId("sharedUser@gmail.com");
+    acl.setRoles(List.of(RoleEnum.SHARED_WITH));
+    measure.setAcls(List.of(acl));
+    when(repository.findById(anyString())).thenReturn(Optional.of(measure));
+
+    var testMeasure = new Measure();
+    testMeasure.setActive(false);
+    testMeasure.setCreatedBy("anotheruser");
+    testMeasure.setId("testid");
+    testMeasure.setMeasureName("MSR01");
+    testMeasure.setVersion(new Version(0, 0, 1));
+    testMeasure.setActive(false);
+    assertThrows(
+        InvalidDraftStatusException.class,
         () -> controller.updateMeasure("testid", testMeasure, principal, "Bearer TOKEN"));
   }
 

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -392,11 +392,11 @@ public class VersionServiceTest {
   @Test
   public void testCreateDraftSuccessfully() {
     TestCaseGroupPopulation clonedTestCaseGroupPopulation =
-            TestCaseGroupPopulation.builder()
-                    .groupId("clonedGroupId1")
-                    .scoring("Cohort")
-                    .populationBasis("boolean")
-                    .build();
+        TestCaseGroupPopulation.builder()
+            .groupId("clonedGroupId1")
+            .scoring("Cohort")
+            .populationBasis("boolean")
+            .build();
     Measure versionedMeasure = buildBasicMeasure();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
@@ -408,7 +408,13 @@ public class VersionServiceTest {
             .measureName("Test")
             .measureMetaData(metaData)
             .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
-            .testCases(List.of(testCase.toBuilder().id(ObjectId.get().toString()).groupPopulations(List.of(clonedTestCaseGroupPopulation)).build()))
+            .testCases(
+                List.of(
+                    testCase
+                        .toBuilder()
+                        .id(ObjectId.get().toString())
+                        .groupPopulations(List.of(clonedTestCaseGroupPopulation))
+                        .build()))
             .build();
 
     when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
@@ -431,7 +437,9 @@ public class VersionServiceTest {
     assertFalse(draft.getGroups().stream().anyMatch(item -> "xyz-p12r-12ert".equals(item.getId())));
     assertThat(draft.getTestCases().size(), is(equalTo(1)));
     assertFalse(draft.getGroups().stream().anyMatch(item -> "testId1".equals(item.getId())));
-    assertThat(draft.getTestCases().get(0).getGroupPopulations().get(0).getGroupId(),is(equalTo("clonedGroupId1")));
+    assertThat(
+        draft.getTestCases().get(0).getGroupPopulations().get(0).getGroupId(),
+        is(equalTo("clonedGroupId1")));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5306](https://jira.cms.gov/browse/MAT-5306)
(Optional) Related Tickets:

### Summary
Blocks users from making changes to drafted measures from the backend

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
