### PR TITLE
MAT-5369: Adding SupplementalData checks against CQL Definitions

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -90,7 +90,7 @@ public class GroupService {
       }
     }
     updateGroupForTestCases(group, measure.getTestCases());
-    measure = measureUtil.validateAllMeasureGroupReturnTypes(measure);
+    measure = measureUtil.validateAllMeasureDependencies(measure);
     measure.setLastModifiedBy(username);
     measure.setLastModifiedAt(Instant.now());
     measureRepository.save(measure);

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -123,7 +123,7 @@ public class MeasureService {
     if (measureUtil.isMeasureCqlChanged(existingMeasure, updatingMeasure)) {
       try {
         outputMeasure =
-            measureUtil.validateAllMeasureGroupReturnTypes(updateElm(updatingMeasure, accessToken));
+            measureUtil.validateAllMeasureDependencies(updateElm(updatingMeasure, accessToken));
         // no errors were encountered so remove the ELM JSON error
         // TODO: remove this when backend validations for CQL/ELM are enhanced
         outputMeasure.setErrors(

--- a/src/main/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidator.java
+++ b/src/main/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidator.java
@@ -1,23 +1,24 @@
 package cms.gov.madie.measure.validations;
 
-import cms.gov.madie.measure.exceptions.InvalidIdException;
-import cms.gov.madie.measure.exceptions.InvalidReturnTypeException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import gov.cms.madie.models.measure.Group;
-import gov.cms.madie.models.measure.Population;
-import gov.cms.madie.models.measure.Stratification;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import cms.gov.madie.measure.exceptions.InvalidReturnTypeException;
+import gov.cms.madie.models.measure.Group;
+import gov.cms.madie.models.measure.Population;
+import gov.cms.madie.models.measure.Stratification;
+import gov.cms.madie.models.measure.SupplementalData;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
+@Slf4j
 public class CqlDefinitionReturnTypeValidator {
 
   /**
@@ -57,6 +58,19 @@ public class CqlDefinitionReturnTypeValidator {
             }
           });
     }
+  }
+
+  public boolean validateSdeDefinition(SupplementalData sde, String elmJson) {
+    boolean result = false;
+    try {
+      Map<String, String> cqlDefinitionReturnTypes = getCqlDefinitionReturnTypes(elmJson);
+      result = cqlDefinitionReturnTypes.containsKey(sde.getDefinition());
+    } catch (JsonProcessingException e) {
+      log.error("Error reading elmJson", e);
+      result = false;
+    }
+
+    return result;
   }
 
   /**

--- a/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
@@ -231,7 +231,7 @@ public class GroupServiceTest implements ResourceUtil {
     doReturn(optional).when(measureRepository).findById(any(String.class));
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group persistedGroup = groupService.createOrUpdateGroup(group1, measure.getId(), "test.user");
@@ -259,7 +259,7 @@ public class GroupServiceTest implements ResourceUtil {
     doReturn(optional).when(measureRepository).findById(any(String.class));
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group persistedGroup = groupService.createOrUpdateGroup(group1, measure.getId(), "test.user");
@@ -288,7 +288,7 @@ public class GroupServiceTest implements ResourceUtil {
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
 
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group persistedGroup =
@@ -323,7 +323,7 @@ public class GroupServiceTest implements ResourceUtil {
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
 
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     // before update
@@ -535,7 +535,7 @@ public class GroupServiceTest implements ResourceUtil {
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
 
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     // before update
@@ -688,7 +688,7 @@ public class GroupServiceTest implements ResourceUtil {
 
     doReturn(measure).when(measureRepository).save(any(Measure.class));
 
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     // before update
@@ -763,7 +763,7 @@ public class GroupServiceTest implements ResourceUtil {
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
     doReturn(optional).when(measureRepository).findById(any(String.class));
     doReturn(measure).when(measureRepository).save(any(Measure.class));
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group group = groupService.createOrUpdateGroup(group2, measure.getId(), "test.user");
@@ -778,7 +778,7 @@ public class GroupServiceTest implements ResourceUtil {
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
     doReturn(optional).when(measureRepository).findById(any(String.class));
     doReturn(measure).when(measureRepository).save(any(Measure.class));
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group group = groupService.createOrUpdateGroup(group2, measure.getId(), "test.user");
@@ -833,7 +833,7 @@ public class GroupServiceTest implements ResourceUtil {
     measure.setElmJson(getData("/test_elm_no_functions.json"));
     Optional<Measure> optional = Optional.of(measure);
     doReturn(optional).when(measureRepository).findById(any(String.class));
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class)))
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     Group group = groupService.createOrUpdateGroup(group1, measure.getId(), "test.user");

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -433,7 +433,7 @@ public class MeasureServiceTest implements ResourceUtil {
 
     Measure expected =
         updated.toBuilder().error(MeasureErrorType.MISMATCH_CQL_POPULATION_RETURN_TYPES).build();
-    when(measureUtil.validateAllMeasureGroupReturnTypes(any(Measure.class))).thenReturn(expected);
+    when(measureUtil.validateAllMeasureDependencies(any(Measure.class))).thenReturn(expected);
     when(measureRepository.save(any(Measure.class))).thenReturn(expected);
 
     Measure output = measureService.updateMeasure(original, "User1", updated, "Access Token");

--- a/src/test/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidatorTest.java
+++ b/src/test/java/cms/gov/madie/measure/validations/CqlDefinitionReturnTypeValidatorTest.java
@@ -1,0 +1,75 @@
+package cms.gov.madie.measure.validations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import cms.gov.madie.measure.utils.ResourceUtil;
+import gov.cms.madie.models.measure.Group;
+import gov.cms.madie.models.measure.Population;
+import gov.cms.madie.models.measure.PopulationType;
+import gov.cms.madie.models.measure.SupplementalData;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.CoreMatchers.is;
+
+class CqlDefinitionReturnTypeValidatorTest implements ResourceUtil {
+
+  @Test
+  void testValidateCqlDefinitionReturnTypes() throws JsonProcessingException {
+    // new group, not in DB, so no ID
+    Group group1 =
+        Group.builder()
+            .scoring("Cohort")
+            .populationBasis("Encounter")
+            .populations(
+                List.of(
+                    new Population(
+                        "id-1",
+                        PopulationType.INITIAL_POPULATION,
+                        "Initial Population",
+                        null,
+                        null)))
+            .groupDescription("Description")
+            .scoringUnit("test-scoring-unit")
+            .build();
+
+    String elmJson = getData("/test_elm.json");
+
+    CqlDefinitionReturnTypeValidator validator = new CqlDefinitionReturnTypeValidator();
+    validator.validateCqlDefinitionReturnTypes(group1, elmJson);
+  }
+
+  @Test
+  void testValidateSdeDefinitions_Valid() {
+    String elmJson = getData("/test_elm.json");
+
+    CqlDefinitionReturnTypeValidator validator = new CqlDefinitionReturnTypeValidator();
+    SupplementalData sde =
+        SupplementalData.builder().definition("fun23").description("Please Help Me").build();
+    boolean isValid = validator.validateSdeDefinition(sde, elmJson);
+    assertThat(isValid, is(true));
+  }
+
+  @Test
+  void testValidateSdeDefinitions_Invalid() {
+    String elmJson = getData("/test_elm.json");
+
+    CqlDefinitionReturnTypeValidator validator = new CqlDefinitionReturnTypeValidator();
+    SupplementalData sde =
+        SupplementalData.builder().definition("fun34").description("Please Help Me").build();
+    boolean isValid = validator.validateSdeDefinition(sde, elmJson);
+    assertThat(isValid, is(false));
+  }
+
+  @Test
+  void testValidateSdeDefinitions_InvalidJson() {
+    String elmJson = "{ curroped: json";
+
+    CqlDefinitionReturnTypeValidator validator = new CqlDefinitionReturnTypeValidator();
+    SupplementalData sde =
+        SupplementalData.builder().definition("fun34").description("Please Help Me").build();
+    boolean isValid = validator.validateSdeDefinition(sde, elmJson);
+    assertThat(isValid, is(false));
+  }
+}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5369](https://jira.cms.gov/browse/MAT-5369)
(Optional) Related Tickets:

### Summary
Adding a check for whether the definitions referenced in SupplementalData are actually in the CQL when it's saved.  The biggest changes are in MeasureUtil where I also refactored some of the previous "PopulationCriteria definition return Type" validation to make everything more readable.

### All Submissions
* [X] This PR has the JIRA linked.
* [X] Required tests are included.
* [X] No extemporaneous files are included (i.e Complied files or testing results).
* [X] This PR is merging into the **correct branch**.
* [X] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
