### PR TITLE
Ignore errors when saving versioned measures to HAPI

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
+++ b/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
@@ -8,10 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClientResponseException;import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
@@ -69,7 +69,13 @@ public class FhirServicesClient {
     HttpHeaders headers = new HttpHeaders();
     headers.set(HttpHeaders.AUTHORIZATION, accessToken);
     HttpEntity<Measure> measureEntity = new HttpEntity<>(measure, headers);
-    return fhirServicesRestTemplate.exchange(uri, HttpMethod.POST, measureEntity, String.class);
+    try {
+      return fhirServicesRestTemplate.exchange(uri, HttpMethod.POST, measureEntity, String.class);
+    } catch (RestClientResponseException e) {
+    // Ignore errors when saving Measures to HAPI as they're never retrieved.
+    return new ResponseEntity<>(
+        e.getResponseBodyAsString(), HttpStatus.valueOf(e.getRawStatusCode()));
+    }
   }
 
   private URI buildMadieFhirServiceUri(String bundleType, String fhirServiceUri) {

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.Instant;
@@ -412,7 +413,8 @@ public class VersionServiceTest {
     updatedMeasure.setMeasureMetaData(updatedMetaData);
     when(measureRepository.save(any(Measure.class))).thenReturn(updatedMeasure);
 
-    when(fhirServicesClient.saveMeasureInHapiFhir(any(), anyString())).thenReturn(null);
+    when(fhirServicesClient.saveMeasureInHapiFhir(any(), anyString()))
+        .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
     versionService.createVersion("testMeasureId", "PATCH", "testUser", "accesstoken");
 


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-0000](https://jira.cms.gov/browse/MAT-0000)
(Optional) Related Tickets:

### Summary

We are moving away from utilizing HAPI as a persistence store. Until the store is fully removed, we can safely ignore failed saves during the measure versioning flow.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
