### PR TITLE
[MAT-5916] Version QDM Measure

### DIFF
--- a/src/main/java/cms/gov/madie/measure/resources/MeasureVersionController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureVersionController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
+import static cms.gov.madie.measure.services.VersionService.VersionValidationResult.TEST_CASE_ERROR;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -32,13 +34,17 @@ public class MeasureVersionController {
   }
 
   @GetMapping("/{id}/version")
-  public ResponseEntity<Measure> checkValidVersion(
+  public ResponseEntity<Void> checkValidVersion(
       @PathVariable("id") String id,
       @RequestParam String versionType,
       Principal principal,
-      @RequestHeader("Authorization") String accessToken)
-      throws Exception {
-    return versionService.checkValidVersioning(id, versionType, principal.getName(), accessToken);
+      @RequestHeader("Authorization") String accessToken) {
+    var validationResult =
+        versionService.checkValidVersioning(id, versionType, principal.getName(), accessToken);
+    if (validationResult == TEST_CASE_ERROR) {
+      return new ResponseEntity<>(HttpStatus.ACCEPTED);
+    }
+    return new ResponseEntity<>(HttpStatus.OK);
   }
 
   @PostMapping("/{id}/draft")

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -46,7 +46,7 @@ public class VersionService {
 
   public enum VersionValidationResult {
     VALID,
-    TEST_CASE_ERROR;
+    TEST_CASE_ERROR
   }
 
   private static final String VERSION_TYPE_MAJOR = "MAJOR";
@@ -248,7 +248,7 @@ public class VersionService {
     }
   }
 
-  protected Version getNextVersion(Measure measure, String versionType) throws Exception {
+  protected Version getNextVersion(Measure measure, String versionType) {
     Version version;
 
     if (VERSION_TYPE_MAJOR.equalsIgnoreCase(versionType)) {
@@ -281,7 +281,7 @@ public class VersionService {
   }
 
   private String generateLibraryContentLine(String cqlLibraryName, Version version) {
-    return "library " + cqlLibraryName + " version " + "\'" + version + "\'";
+    return "library " + cqlLibraryName + " version " + "'" + version + "'";
   }
 
   protected void setMeasureReviewMetaData(Measure measure) {

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -79,11 +79,13 @@ public class VersionService {
     return versionQdmMeasure(versionType, username, measure);
   }
 
-  private Measure versionQdmMeasure(String versionType, String username, Measure measure) throws Exception {
+  private Measure versionQdmMeasure(String versionType, String username, Measure measure)
+      throws Exception {
     return version(versionType, username, measure);
   }
 
-  private Measure versionFhirMeasure(String versionType, String username, String accessToken, Measure measure) throws Exception {
+  private Measure versionFhirMeasure(
+      String versionType, String username, String accessToken, Measure measure) throws Exception {
     Measure savedMeasure = version(versionType, username, measure);
     var measureBundle = fhirServicesClient.getMeasureBundle(savedMeasure, accessToken, "export");
     saveMeasureBundle(savedMeasure, measureBundle, accessToken, username);

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -10,6 +10,7 @@ import gov.cms.madie.models.common.ActionType;
 import gov.cms.madie.models.common.Version;
 import gov.cms.madie.models.measure.ElmJson;
 import gov.cms.madie.models.measure.Export;
+import gov.cms.madie.models.measure.FhirMeasure;
 import gov.cms.madie.models.measure.Group;
 import gov.cms.madie.models.measure.Measure;
 import gov.cms.madie.models.measure.ReviewMetaData;
@@ -42,6 +43,11 @@ public class VersionService {
   private final FhirServicesClient fhirServicesClient;
   private final ExportRepository exportRepository;
   private final MeasureService measureService;
+
+  public enum VersionValidationResult {
+    VALID,
+    TEST_CASE_ERROR;
+  }
 
   private static final String VERSION_TYPE_MAJOR = "MAJOR";
   private static final String VERSION_TYPE_MINOR = "MINOR";

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -109,6 +108,26 @@ public class MeasureVersionControllerTest {
   }
 
   @Test
+  public void testCheckVersionTestCaseErrors() {
+    when(principal.getName()).thenReturn("testUser");
+    Measure updatedMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
+    Version updatedVersion = Version.builder().major(3).minor(0).revisionNumber(0).build();
+    updatedMeasure.setVersion(updatedVersion);
+    MeasureMetaData updatedMetaData = new MeasureMetaData();
+    updatedMetaData.setDraft(false);
+    updatedMeasure.setMeasureMetaData(updatedMetaData);
+
+    when(versionService.checkValidVersioning(anyString(), anyString(), anyString(), anyString()))
+            .thenReturn(VersionService.VersionValidationResult.TEST_CASE_ERROR);
+
+    ResponseEntity<Void> entity =
+            measureVersionController.checkValidVersion(
+                    "testMeasureId", "MAJOR", principal, "accesstoken");
+    assertThat(entity, is(notNullValue()));
+    assertThat(entity.getStatusCode(), is(HttpStatus.ACCEPTED));
+  }
+
+  @Test
   public void testCheckValidVersioningSuccess() {
     when(principal.getName()).thenReturn("testUser");
     Measure updatedMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
@@ -121,15 +140,11 @@ public class MeasureVersionControllerTest {
     when(versionService.checkValidVersioning(anyString(), anyString(), anyString(), anyString()))
         .thenReturn(VersionService.VersionValidationResult.VALID);
 
-    ResponseEntity<Void> entity =
-        measureVersionController.checkValidVersion(
-            "testMeasureId", "MAJOR", principal, "accesstoken");
-    assertThat(entity, is(notNullValue()));
-    assertThat(entity.getStatusCode(), is(HttpStatus.OK));
     ResponseEntity<Void> response =
         measureVersionController.checkValidVersion(
             "testMeasureId", "MAJOR", principal, "accesstoken");
-    assertEquals((HttpStatus.OK), response.getStatusCode());
+    assertThat(response, is(notNullValue()));
+    assertThat(response.getStatusCode(), is(HttpStatus.OK));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
@@ -109,7 +109,7 @@ public class MeasureVersionControllerTest {
   }
 
   @Test
-  public void testCheckValidVersionioningSuccess() throws Exception {
+  public void testCheckValidVersioningSuccess() throws Exception {
     when(principal.getName()).thenReturn("testUser");
     Measure updatedMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
     Version updatedVersion = Version.builder().major(3).minor(0).revisionNumber(0).build();
@@ -117,16 +117,16 @@ public class MeasureVersionControllerTest {
     MeasureMetaData updatedMetaData = new MeasureMetaData();
     updatedMetaData.setDraft(false);
     updatedMeasure.setMeasureMetaData(updatedMetaData);
-    ResponseEntity<?> responseEntity = new ResponseEntity<>("some response body", HttpStatus.OK);
-    when(versionService.checkValidVersioning(anyString(), anyString(), anyString(), anyString()))
-        .thenReturn((ResponseEntity<Measure>) responseEntity);
 
-    ResponseEntity<Measure> entity =
+    when(versionService.checkValidVersioning(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(VersionService.VersionValidationResult.VALID);
+
+    ResponseEntity<Void> entity =
         measureVersionController.checkValidVersion(
             "testMeasureId", "MAJOR", principal, "accesstoken");
     assertThat(entity, is(notNullValue()));
     assertThat(entity.getStatusCode(), is(HttpStatus.OK));
-    ResponseEntity response =
+    ResponseEntity<Void> response =
         measureVersionController.checkValidVersion(
             "testMeasureId", "MAJOR", principal, "accesstoken");
     assertEquals((HttpStatus.OK), response.getStatusCode());

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureVersionControllerTest.java
@@ -109,7 +109,7 @@ public class MeasureVersionControllerTest {
   }
 
   @Test
-  public void testCheckValidVersioningSuccess() throws Exception {
+  public void testCheckValidVersioningSuccess() {
     when(principal.getName()).thenReturn("testUser");
     Measure updatedMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
     Version updatedVersion = Version.builder().major(3).minor(0).revisionNumber(0).build();

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -30,6 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
+import static cms.gov.madie.measure.services.VersionService.VersionValidationResult.TEST_CASE_ERROR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -321,7 +322,7 @@ public class VersionServiceTest {
   }
 
   @Test
-  public void testCheckVersionReturns202() throws Exception {
+  public void testCheckVersionIdentifiesTestCaseErrors() throws Exception {
     Measure existingMeasure =
         Measure.builder()
             .id("testMeasureId")
@@ -339,9 +340,9 @@ public class VersionServiceTest {
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
     when(elmTranslatorClient.hasErrors(any())).thenReturn(false);
-    ResponseEntity response =
+    var validationResult =
         versionService.checkValidVersioning("testMeasureId", "MAJOR", "testUser", "accesstoken");
-    assertEquals((HttpStatus.ACCEPTED), response.getStatusCode());
+    assertEquals(TEST_CASE_ERROR, validationResult);
   }
 
   @Test
@@ -361,8 +362,8 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionMajorSuccess() throws Exception {
-    Measure existingMeasure =
-        Measure.builder()
+    FhirMeasure existingMeasure =
+        FhirMeasure.builder()
             .id("testMeasureId")
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
@@ -438,8 +439,8 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionMinorSuccess() throws Exception {
-    Measure existingMeasure =
-        Measure.builder()
+    FhirMeasure existingMeasure =
+        FhirMeasure.builder()
             .id("testMeasureId")
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
@@ -515,9 +516,9 @@ public class VersionServiceTest {
   }
 
   @Test
-  public void testCreateVersionPatchSuccess() throws Exception {
-    Measure existingMeasure =
-        Measure.builder()
+  public void testCreateFhirVersionPatchSuccess() throws Exception {
+    FhirMeasure existingMeasure =
+        FhirMeasure.builder()
             .id("testMeasureId")
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -111,7 +111,7 @@ public class VersionServiceTest {
           .scoringUnit("test-scoring-unit")
           .build();
 
-  private Instant today = Instant.now();
+  private final Instant today = Instant.now();
 
   @Test
   public void testCheckValidVersioningThrowsResourceNotFoundException() {
@@ -322,7 +322,7 @@ public class VersionServiceTest {
   }
 
   @Test
-  public void testCheckVersionIdentifiesTestCaseErrors() throws Exception {
+  public void testCheckVersionIdentifiesTestCaseErrors() {
     Measure existingMeasure =
         Measure.builder()
             .id("testMeasureId")

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static cms.gov.madie.measure.services.VersionService.VersionValidationResult.TEST_CASE_ERROR;
+import static cms.gov.madie.measure.services.VersionService.VersionValidationResult.VALID;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -346,6 +347,28 @@ public class VersionServiceTest {
   }
 
   @Test
+  public void testCheckVersion() {
+    Measure existingMeasure =
+        Measure.builder()
+            .id("testMeasureId")
+            .createdBy("testUser")
+            .cql("library Test1CQLLib version '2.3.001")
+            .build();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    existingMeasure.setMeasureMetaData(metaData);
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+
+    ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
+    when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
+    when(elmTranslatorClient.hasErrors(any())).thenReturn(false);
+    var validationResult =
+        versionService.checkValidVersioning("testMeasureId", "MAJOR", "testUser", "accesstoken");
+    assertEquals(VALID, validationResult);
+  }
+
+  @Test
   public void testGetNextVersionOtherException() throws Exception {
     Measure existingMeasure =
         Measure.builder()
@@ -439,8 +462,8 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionMinorSuccess() throws Exception {
-    FhirMeasure existingMeasure =
-        FhirMeasure.builder()
+    QdmMeasure existingMeasure =
+            QdmMeasure.builder()
             .id("testMeasureId")
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
@@ -471,19 +494,6 @@ public class VersionServiceTest {
     updatedMeasure.setMeasureMetaData(updatedMetaData);
     when(measureRepository.save(any(Measure.class))).thenReturn(updatedMeasure);
 
-    when(fhirServicesClient.saveMeasureInHapiFhir(any(), anyString()))
-        .thenReturn(ResponseEntity.ok("Created"));
-
-    Export measureExport =
-        Export.builder()
-            .id("testId")
-            .measureId("testMeasureId")
-            .measureBundleJson("test measure json")
-            .build();
-    when(exportRepository.save(any(Export.class))).thenReturn(measureExport);
-    when(fhirServicesClient.getMeasureBundle(any(), anyString(), anyString()))
-        .thenReturn("test measure json");
-
     versionService.createVersion("testMeasureId", "MINOR", "testUser", "accesstoken");
 
     verify(measureRepository, times(1)).save(measureCaptor.capture());
@@ -506,13 +516,6 @@ public class VersionServiceTest {
             .truncatedTo(ChronoUnit.MINUTES)
             .compareTo(today.truncatedTo(ChronoUnit.MINUTES)),
         is(0));
-
-    verify(exportRepository, times(1)).save(exportArgumentCaptor.capture());
-    Export savedExport = exportArgumentCaptor.getValue();
-    assertEquals(savedExport.getMeasureId(), savedValue.getId());
-    assertEquals(measureExport.getMeasureBundleJson(), savedExport.getMeasureBundleJson());
-
-    verify(fhirServicesClient, times(1)).saveMeasureInHapiFhir(updatedMeasure, "accesstoken");
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5916](https://jira.cms.gov/browse/MAT-5916)
(Optional) Related Tickets:

### Summary
The original versioning flow (FHIR based) worked fine with the exception of the FHIR Bundle creation and save at the end would fail when presented with a QDM Measure.

Reorganized and refactored the flow to branch based on whether the Measure is an instace of FhirMeasure, and assumed to be a QDM Measure if not.
Refactor versioning flow:
  - Separate QDM and FHIR measure versioning 
  - Use common validation method
  - Split out common versioning logic into its own method


Introduced an enum to identify the different kinds of version validation results instead of returning a ResponseEntity from the Service.
Refactor version validation:   
  - move common authn and validation checks to their own method
  - return validation result enum
  - simply invalid test case check lambda

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
