### PR TITLE
MAT-5968: remove single export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.6.0-SNAPSHOT</version>
+      <version>0.6.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>ca.uhn.hapi.fhir</groupId>

--- a/src/main/java/cms/gov/madie/measure/resources/ExportController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ExportController.java
@@ -1,20 +1,21 @@
 package cms.gov.madie.measure.resources;
 
-import cms.gov.madie.measure.services.BundleService;
-import java.security.Principal;
-import java.util.Optional;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.services.BundleService;
 import cms.gov.madie.measure.services.FhirServicesClient;
 import cms.gov.madie.measure.utils.ControllerUtil;
 import cms.gov.madie.measure.utils.ExportFileNamesUtil;
+import gov.cms.madie.models.measure.Measure;
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import cms.gov.madie.measure.repositories.MeasureRepository;
-import gov.cms.madie.models.measure.Measure;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
@@ -87,7 +88,7 @@ public class ExportController {
       Principal principal,
       @RequestHeader("Authorization") String accessToken,
       @PathVariable String measureId,
-      @RequestBody String... testCaseId) {
+      @RequestBody List<String> testCaseId) {
 
     final String username = principal.getName();
     log.info("User [{}] is attempting to export test cases for [{}]", username, measureId);
@@ -107,6 +108,6 @@ public class ExportController {
                 + ExportFileNamesUtil.getTestCaseExportZipName(measure)
                 + ".zip\"")
         .contentType(MediaType.APPLICATION_OCTET_STREAM)
-        .body(null);
+        .body(fhirServicesClient.getTestCaseExports(measure, accessToken, testCaseId));
   }
 }

--- a/src/main/java/cms/gov/madie/measure/resources/ExportController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ExportController.java
@@ -82,12 +82,12 @@ public class ExportController {
         .body(fhirServicesClient.getTestCaseExport(measure, accessToken, testCaseId));
   }
 
-  @GetMapping(path = ControllerUtil.TEST_CASES + "/exports", produces = "application/zip")
+  @PutMapping(path = ControllerUtil.TEST_CASES + "/exports", produces = "application/zip")
   public ResponseEntity<byte[]> getTestCaseExport(
       Principal principal,
       @RequestHeader("Authorization") String accessToken,
       @PathVariable String measureId,
-      @RequestParam String... testCaseId) {
+      @RequestBody String... testCaseId) {
 
     final String username = principal.getName();
     log.info("User [{}] is attempting to export test cases for [{}]", username, measureId);

--- a/src/main/java/cms/gov/madie/measure/resources/ExportController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ExportController.java
@@ -1,7 +1,5 @@
 package cms.gov.madie.measure.resources;
 
-import static java.util.Arrays.asList;
-
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.services.BundleService;
@@ -53,37 +51,6 @@ public class ExportController {
             "attachment;filename=\"" + ExportFileNamesUtil.getExportFileName(measure) + ".zip\"")
         .contentType(MediaType.APPLICATION_OCTET_STREAM)
         .body(bundleService.exportBundleMeasure(measure, accessToken));
-  }
-
-  @Deprecated
-  @GetMapping(
-      path = ControllerUtil.TEST_CASES + "/{testCaseId}/exports",
-      produces = "application/zip")
-  public ResponseEntity<byte[]> getTestCaseExport(
-      Principal principal,
-      @RequestHeader("Authorization") String accessToken,
-      @PathVariable String measureId,
-      @PathVariable String testCaseId) {
-
-    final String username = principal.getName();
-    log.info("User [{}] is attempting to export test case [{}]", username, testCaseId);
-
-    Optional<Measure> measureOptional = measureRepository.findById(measureId);
-
-    if (measureOptional.isEmpty()) {
-      throw new ResourceNotFoundException("Measure", measureId);
-    }
-
-    Measure measure = measureOptional.get();
-
-    return ResponseEntity.ok()
-        .header(
-            HttpHeaders.CONTENT_DISPOSITION,
-            "attachment;filename=\""
-                + ExportFileNamesUtil.getTestCaseExportZipName(measure)
-                + ".zip\"")
-        .contentType(MediaType.APPLICATION_OCTET_STREAM)
-        .body(fhirServicesClient.getTestCaseExports(measure, accessToken, asList(testCaseId)));
   }
 
   @PutMapping(path = ControllerUtil.TEST_CASES + "/exports", produces = "application/zip")

--- a/src/main/java/cms/gov/madie/measure/resources/ExportController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ExportController.java
@@ -1,5 +1,7 @@
 package cms.gov.madie.measure.resources;
 
+import static java.util.Arrays.asList;
+
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.services.BundleService;
@@ -53,6 +55,7 @@ public class ExportController {
         .body(bundleService.exportBundleMeasure(measure, accessToken));
   }
 
+  @Deprecated
   @GetMapping(
       path = ControllerUtil.TEST_CASES + "/{testCaseId}/exports",
       produces = "application/zip")
@@ -80,7 +83,7 @@ public class ExportController {
                 + ExportFileNamesUtil.getTestCaseExportZipName(measure)
                 + ".zip\"")
         .contentType(MediaType.APPLICATION_OCTET_STREAM)
-        .body(fhirServicesClient.getTestCaseExport(measure, accessToken, testCaseId));
+        .body(fhirServicesClient.getTestCaseExports(measure, accessToken, asList(testCaseId)));
   }
 
   @PutMapping(path = ControllerUtil.TEST_CASES + "/exports", produces = "application/zip")

--- a/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
+++ b/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
@@ -107,7 +107,7 @@ public class FhirServicesClient {
         URI.create(
             fhirServicesConfig.getMadieFhirServiceBaseUrl()
                 + fhirServicesConfig.madieFhirServiceTestCaseUri
-                + "/exportAll");
+                + "/export-all");
     HttpHeaders headers = new HttpHeaders();
     headers.set(HttpHeaders.AUTHORIZATION, accessToken);
     headers.set(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);

--- a/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
+++ b/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
@@ -84,24 +84,6 @@ public class FhirServicesClient {
     }
   }
 
-  public byte[] getTestCaseExport(Measure measure, String accessToken, String testCaseId) {
-    URI uri =
-        URI.create(
-            fhirServicesConfig.getMadieFhirServiceBaseUrl()
-                + fhirServicesConfig.madieFhirServiceTestCaseUri
-                + "/"
-                + testCaseId
-                + "/exports");
-    HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, accessToken);
-    headers.set(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);
-    headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-    HttpEntity<Measure> measureEntity = new HttpEntity<>(measure, headers);
-    return fhirServicesRestTemplate
-        .exchange(uri, HttpMethod.PUT, measureEntity, byte[].class)
-        .getBody();
-  }
-
   public byte[] getTestCaseExports(Measure measure, String accessToken, List<String> testCaseId) {
     URI uri =
         URI.create(

--- a/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
+++ b/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
@@ -1,8 +1,10 @@
 package cms.gov.madie.measure.services;
 
 import cms.gov.madie.measure.config.FhirServicesConfig;
+import gov.cms.madie.models.dto.ExportDTO;
 import gov.cms.madie.models.measure.Measure;
 import java.net.URI;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -95,6 +97,26 @@ public class FhirServicesClient {
     headers.set(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);
     headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
     HttpEntity<Measure> measureEntity = new HttpEntity<>(measure, headers);
+    return fhirServicesRestTemplate
+        .exchange(uri, HttpMethod.PUT, measureEntity, byte[].class)
+        .getBody();
+  }
+
+  public byte[] getTestCaseExports(Measure measure, String accessToken, List<String> testCaseId) {
+    URI uri =
+        URI.create(
+            fhirServicesConfig.getMadieFhirServiceBaseUrl()
+                + fhirServicesConfig.madieFhirServiceTestCaseUri
+                + "/exportAll");
+    HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.AUTHORIZATION, accessToken);
+    headers.set(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);
+    headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+    ExportDTO dto = ExportDTO.builder().measure(measure).testCaseIds(testCaseId).build();
+
+    HttpEntity<ExportDTO> measureEntity = new HttpEntity<>(dto, headers);
+
     return fhirServicesRestTemplate
         .exchange(uri, HttpMethod.PUT, measureEntity, byte[].class)
         .getBody();

--- a/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
@@ -61,37 +61,6 @@ class ExportControllerTest {
   }
 
   @Test
-  void getTestCaseExport() {
-    Principal principal = mock(Principal.class);
-    when(principal.getName()).thenReturn("test.user");
-    final Measure measure =
-        Measure.builder()
-            .ecqmTitle("test_ecqm_title")
-            .version(new Version(0, 0, 0))
-            .model("QiCore 4.1.1")
-            .createdBy("test.user")
-            .build();
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(measure));
-    when(fhirServicesClient.getTestCaseExports(any(Measure.class), anyString(), anyList()))
-        .thenReturn(new byte[0]);
-    ResponseEntity<byte[]> output =
-        exportController.getTestCaseExport(
-            principal, "access-token", "example-measure-id", "example-test-case-id");
-    assertEquals(HttpStatus.OK, output.getStatusCode());
-  }
-
-  @Test
-  void getTestCaseExportThrowsResourceNotFoundException() {
-    Principal principal = mock(Principal.class);
-    when(measureRepository.findById(anyString())).thenReturn(Optional.empty());
-    assertThrows(
-        ResourceNotFoundException.class,
-        () ->
-            exportController.getTestCaseExport(
-                principal, "access-token", "example-measure-id", "example-test-case-id"));
-  }
-
-  @Test
   void getTestCaseExportAll() {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn("test.user");

--- a/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
@@ -1,35 +1,25 @@
 package cms.gov.madie.measure.resources;
 
-import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
-import cms.gov.madie.measure.exceptions.UnauthorizedException;
-import cms.gov.madie.measure.repositories.MeasureRepository;
-import cms.gov.madie.measure.services.BundleService;
-import cms.gov.madie.measure.services.FhirServicesClient;
-import gov.cms.madie.models.access.AclSpecification;
-import gov.cms.madie.models.access.RoleEnum;
-import gov.cms.madie.models.measure.Measure;
-import gov.cms.madie.models.common.Version;
-import java.io.OutputStream;
-import java.util.Arrays;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.engine.reporting.ReportEntry;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
-
-import java.security.Principal;
-import java.util.List;
-import java.util.Optional;
-
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
+
+import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.services.BundleService;
+import cms.gov.madie.measure.services.FhirServicesClient;
+import gov.cms.madie.models.common.Version;
+import gov.cms.madie.models.measure.Measure;
+import java.security.Principal;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
 class ExportControllerTest {
@@ -82,7 +72,7 @@ class ExportControllerTest {
             .createdBy("test.user")
             .build();
     when(measureRepository.findById(anyString())).thenReturn(Optional.of(measure));
-    when(fhirServicesClient.getTestCaseExport(any(Measure.class), anyString(), anyString()))
+    when(fhirServicesClient.getTestCaseExports(any(Measure.class), anyString(), anyList()))
         .thenReturn(new byte[0]);
     ResponseEntity<byte[]> output =
         exportController.getTestCaseExport(
@@ -106,18 +96,21 @@ class ExportControllerTest {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn("test.user");
     final Measure measure =
-            Measure.builder()
-                    .ecqmTitle("test_ecqm_title")
-                    .version(new Version(0, 0, 0))
-                    .model("QiCore 4.1.1")
-                    .createdBy("test.user")
-                    .build();
+        Measure.builder()
+            .ecqmTitle("test_ecqm_title")
+            .version(new Version(0, 0, 0))
+            .model("QiCore 4.1.1")
+            .createdBy("test.user")
+            .build();
     when(measureRepository.findById(anyString())).thenReturn(Optional.of(measure));
     when(fhirServicesClient.getTestCaseExports(any(Measure.class), anyString(), anyList()))
-            .thenReturn(new byte[0]);
+        .thenReturn(new byte[0]);
     ResponseEntity<byte[]> output =
-            exportController.getTestCaseExport(
-                    principal, "access-token", "example-measure-id", asList("example-test-case-id-1", "example-test-case-id-2"));
+        exportController.getTestCaseExport(
+            principal,
+            "access-token",
+            "example-measure-id",
+            asList("example-test-case-id-1", "example-test-case-id-2"));
     assertEquals(HttpStatus.OK, output.getStatusCode());
   }
 
@@ -126,9 +119,12 @@ class ExportControllerTest {
     Principal principal = mock(Principal.class);
     when(measureRepository.findById(anyString())).thenReturn(Optional.empty());
     assertThrows(
-            ResourceNotFoundException.class,
-            () ->
-                    exportController.getTestCaseExport(
-                            principal, "access-token", "example-measure-id", asList("example-test-case-id-1", "example-test-case-id-2")));
+        ResourceNotFoundException.class,
+        () ->
+            exportController.getTestCaseExport(
+                principal,
+                "access-token",
+                "example-measure-id",
+                asList("example-test-case-id-1", "example-test-case-id-2")));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/ExportControllerTest.java
@@ -26,6 +26,7 @@ import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -98,5 +99,36 @@ class ExportControllerTest {
         () ->
             exportController.getTestCaseExport(
                 principal, "access-token", "example-measure-id", "example-test-case-id"));
+  }
+
+  @Test
+  void getTestCaseExportAll() {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn("test.user");
+    final Measure measure =
+            Measure.builder()
+                    .ecqmTitle("test_ecqm_title")
+                    .version(new Version(0, 0, 0))
+                    .model("QiCore 4.1.1")
+                    .createdBy("test.user")
+                    .build();
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(measure));
+    when(fhirServicesClient.getTestCaseExports(any(Measure.class), anyString(), anyList()))
+            .thenReturn(new byte[0]);
+    ResponseEntity<byte[]> output =
+            exportController.getTestCaseExport(
+                    principal, "access-token", "example-measure-id", asList("example-test-case-id-1", "example-test-case-id-2"));
+    assertEquals(HttpStatus.OK, output.getStatusCode());
+  }
+
+  @Test
+  void getTestCaseExportAllThrowsResourceNotFoundException() {
+    Principal principal = mock(Principal.class);
+    when(measureRepository.findById(anyString())).thenReturn(Optional.empty());
+    assertThrows(
+            ResourceNotFoundException.class,
+            () ->
+                    exportController.getTestCaseExport(
+                            principal, "access-token", "example-measure-id", asList("example-test-case-id-1", "example-test-case-id-2")));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
@@ -22,6 +22,7 @@ import org.springframework.web.client.RestTemplate;
 import java.net.URI;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -217,6 +218,23 @@ class FhirServicesClientTest {
             .exchange(any(URI.class), eq(HttpMethod.PUT), any(HttpEntity.class), any(Class.class)))
         .thenReturn(ResponseEntity.ok(new byte[0]));
     byte[] output = fhirServicesClient.getTestCaseExport(measure, accessToken, "test-case-id");
+    assertNotNull(output);
+  }
+
+  @Test
+  void testGetTestCaseExports() {
+    Measure measure =
+            Measure.builder()
+                    .id("testMeasureId")
+                    .measureSetId("testMeasureSetId")
+                    .createdBy("testUser")
+                    .cql("library Test1CQLLib version '2.3.001'")
+                    .build();
+    when(fhirServicesConfig
+            .fhirServicesRestTemplate()
+            .exchange(any(URI.class), eq(HttpMethod.PUT), any(HttpEntity.class), any(Class.class)))
+            .thenReturn(ResponseEntity.ok(new byte[0]));
+    byte[] output = fhirServicesClient.getTestCaseExports(measure, accessToken, asList("test-case-id-1", "test=case=id-2"));
     assertNotNull(output);
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
@@ -1,7 +1,23 @@
 package cms.gov.madie.measure.services;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import cms.gov.madie.measure.config.FhirServicesConfig;
 import gov.cms.madie.models.measure.Measure;
+import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,23 +34,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
-
-import java.net.URI;
-import java.util.List;
-
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class FhirServicesClientTest {
@@ -205,7 +204,7 @@ class FhirServicesClientTest {
   }
 
   @Test
-  void testGetTestCaseExport() {
+  void testGetTestCaseExports() {
     Measure measure =
         Measure.builder()
             .id("testMeasureId")
@@ -217,24 +216,9 @@ class FhirServicesClientTest {
             .fhirServicesRestTemplate()
             .exchange(any(URI.class), eq(HttpMethod.PUT), any(HttpEntity.class), any(Class.class)))
         .thenReturn(ResponseEntity.ok(new byte[0]));
-    byte[] output = fhirServicesClient.getTestCaseExport(measure, accessToken, "test-case-id");
-    assertNotNull(output);
-  }
-
-  @Test
-  void testGetTestCaseExports() {
-    Measure measure =
-            Measure.builder()
-                    .id("testMeasureId")
-                    .measureSetId("testMeasureSetId")
-                    .createdBy("testUser")
-                    .cql("library Test1CQLLib version '2.3.001'")
-                    .build();
-    when(fhirServicesConfig
-            .fhirServicesRestTemplate()
-            .exchange(any(URI.class), eq(HttpMethod.PUT), any(HttpEntity.class), any(Class.class)))
-            .thenReturn(ResponseEntity.ok(new byte[0]));
-    byte[] output = fhirServicesClient.getTestCaseExports(measure, accessToken, asList("test-case-id-1", "test=case=id-2"));
+    byte[] output =
+        fhirServicesClient.getTestCaseExports(
+            measure, accessToken, asList("test-case-id-1", "test=case=id-2"));
     assertNotNull(output);
   }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5968](https://jira.cms.gov/browse/MAT-5968)
(Optional) Related Tickets:

### Summary
Deprecates the single export endpoint and changes the fhir service call to the one to many call that generates the readme file

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
