### PR TITLE
[MAT-6524] Re-add observations after verifying population criteria match

### DIFF
--- a/madie-checkstyle.xml
+++ b/madie-checkstyle.xml
@@ -30,6 +30,7 @@
         <!-- https://checkstyle.sourceforge.io/config_sizes.html#MethodLength -->
         <module name="MethodLength">
             <property name="tokens" value="METHOD_DEF" />
+            <property name="countEmpty" value="false" />
             <property name="max" value="60" />
         </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -247,28 +247,20 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.theoryinpractise</groupId>
-        <artifactId>googleformatter-maven-plugin</artifactId>
-        <version>1.7.3</version>
+        <groupId>com.spotify.fmt</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.21.1</version>
         <executions>
           <execution>
-            <id>reformat-sources</id>
-            <phase>process-sources</phase>
             <goals>
               <goal>format</goal>
             </goals>
-            <configuration>
-              <includeStale>false</includeStale>
-              <style>GOOGLE</style>
-              <formatMain>true</formatMain>
-              <formatTest>true</formatTest>
-              <filterModified>false</filterModified>
-              <skip>false</skip>
-              <fixImports>false</fixImports>
-              <maxLineLength>100</maxLineLength>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <skipSortingImports>true</skipSortingImports>
+          <style>google</style>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/cms/gov/madie/measure/resources/BundleController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/BundleController.java
@@ -3,7 +3,6 @@ package cms.gov.madie.measure.resources;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.services.BundleService;
-import cms.gov.madie.measure.utils.ControllerUtil;
 import gov.cms.madie.models.measure.Measure;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -1,7 +1,6 @@
 package cms.gov.madie.measure.services;
 
 import cms.gov.madie.measure.exceptions.InvalidDraftStatusException;
-import cms.gov.madie.measure.exceptions.InvalidGroupException;
 import cms.gov.madie.measure.exceptions.InvalidIdException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -176,8 +176,7 @@ public class MeasureService {
             measureUtil.removeError(outputMeasure.getErrors(), MeasureErrorType.ERRORS_ELM_JSON));
       } catch (CqlElmTranslationErrorException ex) {
         outputMeasure =
-            updatingMeasure
-                .toBuilder()
+            updatingMeasure.toBuilder()
                 .cqlErrors(true)
                 .error(MeasureErrorType.ERRORS_ELM_JSON)
                 .build();

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -509,10 +509,16 @@ public class TestCaseService {
           getTestCaseGroupPopulationsFromImportRequest(
               model, testCaseImportRequest.getJson(), measure);
       List<Group> groups = testCaseServiceUtil.getGroupsWithValidPopulations(measure.getGroups());
+      // See if the main populations (non-observation and strats) match between the measure's and
+      // the incoming test case's pop criteria.
       boolean matched =
           testCaseServiceUtil.matchCriteriaGroups(testCaseGroupPopulations, groups, newTestCase);
-      assignObservationAndStratificationValuesForQdm(
-          matched, model, testCaseGroupPopulations, newTestCase, groups);
+
+      // Ignore stratifications for QICore
+      if (matched && ModelType.QDM_5_6.getValue().equalsIgnoreCase(model)) {
+        testCaseServiceUtil.assignStratificationValuesQdm(
+            testCaseGroupPopulations, newTestCase, groups.get(0).getPopulationBasis());
+      }
 
       String warningMessage = null;
       if (!matched) {

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -250,8 +250,7 @@ public class TestCaseService {
       final HapiOperationOutcome hapiOperationOutcome = validateTestCaseJson(testCase, accessToken);
       return testCase == null
           ? null
-          : testCase
-              .toBuilder()
+          : testCase.toBuilder()
               .hapiOperationOutcome(hapiOperationOutcome)
               .validResource(hapiOperationOutcome != null && hapiOperationOutcome.isSuccessful())
               .build();
@@ -324,7 +323,8 @@ public class TestCaseService {
       String measureId, String testCaseId, boolean validate, String accessToken) {
     TestCase testCase =
         Optional.ofNullable(findMeasureById(measureId).getTestCases())
-            .orElseThrow(() -> new ResourceNotFoundException("Test Case", testCaseId)).stream()
+            .orElseThrow(() -> new ResourceNotFoundException("Test Case", testCaseId))
+            .stream()
             .filter(tc -> tc.getId().equals(testCaseId))
             .findFirst()
             .orElse(null);

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -19,8 +19,6 @@ import gov.cms.madie.models.measure.TestCaseGroupPopulation;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -194,15 +192,13 @@ public class VersionService {
                       testCaseGroups.stream()
                           .map(
                               testCaseGroupPopulation ->
-                                  testCaseGroupPopulation
-                                      .toBuilder()
+                                  testCaseGroupPopulation.toBuilder()
                                       .groupId(
                                           draftGroups.get(indexHolder.getAndIncrement()).getId())
                                       .build())
                           .toList());
                 }
-                return testCase
-                    .toBuilder()
+                return testCase.toBuilder()
                     .id(ObjectId.get().toString())
                     .groupPopulations(updatedTestCaseGroupPopulations)
                     .build();

--- a/src/test/java/cms/gov/madie/measure/config/DeleteRiskAdjustmentDefinitionsChangeUnitTest.java
+++ b/src/test/java/cms/gov/madie/measure/config/DeleteRiskAdjustmentDefinitionsChangeUnitTest.java
@@ -19,28 +19,27 @@ import org.springframework.data.mongodb.core.query.Update;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteRiskAdjustmentDefinitionsChangeUnitTest {
-    @Mock private MeasureRepository measureRepository;
-    @Mock private MongoOperations mongoOperations;
+  @Mock private MeasureRepository measureRepository;
+  @Mock private MongoOperations mongoOperations;
 
-    @Test
-    public void testDeleteRiskAdjustmentsDescriptions() {
-        Query query = new Query(Criteria.where("riskAdjustments").exists(true));
-        Update update = new Update().unset("riskAdjustments.$[].description");
-        BulkOperations bulkOperations = mock(BulkOperations.class);
+  @Test
+  public void testDeleteRiskAdjustmentsDescriptions() {
+    Query query = new Query(Criteria.where("riskAdjustments").exists(true));
+    Update update = new Update().unset("riskAdjustments.$[].description");
+    BulkOperations bulkOperations = mock(BulkOperations.class);
 
-        when(mongoOperations.bulkOps(BulkOperations.BulkMode.UNORDERED, Measure.class))
-                .thenReturn(bulkOperations);
+    when(mongoOperations.bulkOps(BulkOperations.BulkMode.UNORDERED, Measure.class))
+        .thenReturn(bulkOperations);
 
-        new DeleteRiskAdjustmentsDescriptionsChangeUnit()
-                .deleteAdjustmentDescriptions(mongoOperations);
+    new DeleteRiskAdjustmentsDescriptionsChangeUnit().deleteAdjustmentDescriptions(mongoOperations);
 
-        verify(bulkOperations, new Times(1)).updateMulti(query, update);
-        verify(bulkOperations, new Times(1)).execute();
-    }
+    verify(bulkOperations, new Times(1)).updateMulti(query, update);
+    verify(bulkOperations, new Times(1)).execute();
+  }
 
-    @Test
-    void testRollback() {
-        new DeleteRiskAdjustmentsDescriptionsChangeUnit().rollbackExecution();
-        verifyNoInteractions(measureRepository);
-    }
+  @Test
+  void testRollback() {
+    new DeleteRiskAdjustmentsDescriptionsChangeUnit().rollbackExecution();
+    verifyNoInteractions(measureRepository);
+  }
 }

--- a/src/test/java/cms/gov/madie/measure/config/UpdateTestCaseResourceFullUrlsChangeUnitTest.java
+++ b/src/test/java/cms/gov/madie/measure/config/UpdateTestCaseResourceFullUrlsChangeUnitTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;

--- a/src/test/java/cms/gov/madie/measure/config/VersionConverterTest.java
+++ b/src/test/java/cms/gov/madie/measure/config/VersionConverterTest.java
@@ -3,7 +3,6 @@ package cms.gov.madie.measure.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
-import cms.gov.madie.measure.config.VersionConverter;
 import gov.cms.madie.models.common.Version;
 
 public class VersionConverterTest {

--- a/src/test/java/cms/gov/madie/measure/resources/BundleControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/BundleControllerTest.java
@@ -3,7 +3,6 @@ package cms.gov.madie.measure.resources;
 import cms.gov.madie.measure.exceptions.BundleOperationException;
 import cms.gov.madie.measure.exceptions.CqlElmTranslationErrorException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
-import cms.gov.madie.measure.exceptions.UnauthorizedException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.services.BundleService;
 import gov.cms.madie.models.access.AclSpecification;

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
@@ -279,8 +279,7 @@ public class MeasureControllerMvcTest {
     metaData.setDevelopers(developers);
     metaData.setGuidance(guidance);
     final Measure updatingMeasure =
-        priorMeasure
-            .toBuilder()
+        priorMeasure.toBuilder()
             .active(false)
             .measureMetaData(metaData)
             .ecqmTitle(ecqmTitle)

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -182,8 +182,7 @@ class MeasureControllerTest {
     measure1.setMeasurementPeriodStart(new Date("12/02/2020"));
     measure1.setMeasurementPeriodEnd(new Date("12/02/2021"));
     Measure originalMeasure =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .id("5399aba6e4b0ae375bfdca88")
             .createdAt(createdAt)
             .createdBy("test.user2")
@@ -192,8 +191,7 @@ class MeasureControllerTest {
     Instant original = Instant.now().minus(140, ChronoUnit.HOURS);
 
     Measure m1 =
-        originalMeasure
-            .toBuilder()
+        originalMeasure.toBuilder()
             .createdBy("test.user")
             .createdAt(original)
             .measurementPeriodStart(new Date("12/02/2021"))
@@ -207,8 +205,7 @@ class MeasureControllerTest {
         .thenReturn(m1);
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            originalMeasure
-                .toBuilder()
+            originalMeasure.toBuilder()
                 .measureSet(MeasureSet.builder().owner("test.user").build())
                 .build());
 
@@ -250,8 +247,7 @@ class MeasureControllerTest {
     measure1.setMeasurementPeriodStart(new Date("12/02/2020"));
     measure1.setMeasurementPeriodEnd(new Date("12/02/2021"));
     Measure originalMeasure =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .id("5399aba6e4b0ae375bfdca88")
             .active(true)
             .createdAt(createdAt)
@@ -261,8 +257,7 @@ class MeasureControllerTest {
     Instant original = Instant.now().minus(140, ChronoUnit.HOURS);
 
     Measure m1 =
-        originalMeasure
-            .toBuilder()
+        originalMeasure.toBuilder()
             .createdBy("test.user")
             .createdAt(original)
             .measurementPeriodStart(new Date("12/02/2021"))
@@ -274,8 +269,7 @@ class MeasureControllerTest {
 
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            originalMeasure
-                .toBuilder()
+            originalMeasure.toBuilder()
                 .measureSet(MeasureSet.builder().owner("test.user2").build())
                 .build());
     doNothing().when(measureService).verifyAuthorization(anyString(), any(Measure.class));
@@ -349,8 +343,7 @@ class MeasureControllerTest {
     measure1.setMeasureMetaData(MeasureMetaData.builder().draft(true).build());
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            measure1
-                .toBuilder()
+            measure1.toBuilder()
                 .measureSet(MeasureSet.builder().owner("validuser@gmail.com").build())
                 .build());
     doNothing().when(measureService).verifyAuthorization(anyString(), any(Measure.class));
@@ -405,8 +398,7 @@ class MeasureControllerTest {
     acl.setRoles(List.of(RoleEnum.SHARED_WITH));
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            measure1
-                .toBuilder()
+            measure1.toBuilder()
                 .measureSet(MeasureSet.builder().owner("MSR01").acls(List.of(acl)).build())
                 .build());
     doNothing().when(measureService).verifyAuthorization(anyString(), any(Measure.class));
@@ -438,8 +430,7 @@ class MeasureControllerTest {
     acl.setRoles(List.of(RoleEnum.SHARED_WITH));
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            measure1
-                .toBuilder()
+            measure1.toBuilder()
                 .measureSet(MeasureSet.builder().owner("test.user").acls(List.of(acl)).build())
                 .build());
 
@@ -505,8 +496,7 @@ class MeasureControllerTest {
     measure1.setId("testid");
     when(measureService.findMeasureById(anyString()))
         .thenReturn(
-            measure1
-                .toBuilder()
+            measure1.toBuilder()
                 .measureSet(MeasureSet.builder().owner("test.user").build())
                 .build());
     doThrow(new UnauthorizedException("Measure", "testid", "unAuthorized user"))

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -297,8 +297,7 @@ public class MeasureServiceTest implements ResourceUtil {
   public void testCreateMeasureSuccessfullyWithNoCql() {
     String usr = "john rao";
     Measure measureToSave =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .measurementPeriodStart(Date.from(Instant.now().minus(38, ChronoUnit.DAYS)))
             .measurementPeriodEnd(Date.from(Instant.now().minus(11, ChronoUnit.DAYS)))
             .measureSetId("msid-1")
@@ -325,8 +324,7 @@ public class MeasureServiceTest implements ResourceUtil {
   @Test
   public void testCreateMeasureSuccessfullyWithValidCql() {
     Measure measureToSave =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .measurementPeriodStart(Date.from(Instant.now().minus(38, ChronoUnit.DAYS)))
             .measurementPeriodEnd(Date.from(Instant.now().minus(11, ChronoUnit.DAYS)))
             .measureSetId("msid-1")
@@ -355,8 +353,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Set<MeasureErrorType> errors =
         Set.of(MeasureErrorType.ERRORS_ELM_JSON, MeasureErrorType.INVALID_TERMINOLOGY);
     Measure measureToSave =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .measurementPeriodStart(Date.from(Instant.now().minus(38, ChronoUnit.DAYS)))
             .measurementPeriodEnd(Date.from(Instant.now().minus(11, ChronoUnit.DAYS)))
             .cqlLibraryName("VTE")
@@ -390,8 +387,7 @@ public class MeasureServiceTest implements ResourceUtil {
   @Test
   public void testCreateMeasureWhenLibraryNameDuplicate() {
     Measure measureToSave =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .measurementPeriodStart(Date.from(Instant.now().minus(38, ChronoUnit.DAYS)))
             .measurementPeriodEnd(Date.from(Instant.now().minus(11, ChronoUnit.DAYS)))
             .cqlLibraryName("VTE")
@@ -411,8 +407,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Instant startInstant = Instant.now();
     Instant endInstant = startInstant.plus(2, ChronoUnit.DAYS);
     Measure measureToSave =
-        measure1
-            .toBuilder()
+        measure1.toBuilder()
             .measurementPeriodStart(Date.from(startInstant))
             .measurementPeriodEnd(Date.from(endInstant))
             .cqlLibraryName("VTE")
@@ -524,8 +519,7 @@ public class MeasureServiceTest implements ResourceUtil {
             .build();
 
     Measure updated =
-        original
-            .toBuilder()
+        original.toBuilder()
             .createdAt(Instant.now())
             .createdBy("SomebodyElse")
             .lastModifiedAt(null)

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
@@ -418,8 +418,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     final String accessToken = "Bearer Token";
     TestCaseService spy = Mockito.spy(testCaseService);
     TestCase validatedTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .hapiOperationOutcome(HapiOperationOutcome.builder().build())
             .validResource(true)
             .build();
@@ -805,8 +804,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
     Instant createdAt = Instant.now().minus(300, ChronoUnit.SECONDS);
     TestCase originalTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdAt(createdAt)
             .createdBy("test.user5")
             .lastModifiedAt(createdAt)
@@ -834,8 +832,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertNotNull(savedMeasure.getTestCases());
     assertEquals(1, savedMeasure.getTestCases().size());
     TestCase expectedTestCase =
-        updatedTestCase
-            .toBuilder()
+        updatedTestCase.toBuilder()
             .hapiOperationOutcome(
                 HapiOperationOutcome.builder()
                     .code(500)
@@ -869,8 +866,7 @@ public class TestCaseServiceTest implements ResourceUtil {
             + "    }\n"
             + "  } ]             }";
     TestCase originalTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdAt(createdAt)
             .createdBy("test.user5")
             .lastModifiedAt(createdAt)
@@ -881,8 +877,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     List<TestCase> testCases = new ArrayList<>();
     testCases.add(originalTestCase);
     Measure originalMeasure =
-        measure
-            .toBuilder()
+        measure.toBuilder()
             .model(ModelType.QI_CORE.getValue())
             .cqlLibraryName("Test1CQLLibraryName")
             .testCases(testCases)
@@ -942,8 +937,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     Instant createdAt = Instant.now().minus(300, ChronoUnit.SECONDS);
     String json = "invalid test case json";
     TestCase originalTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdAt(createdAt)
             .createdBy("test.user5")
             .lastModifiedAt(createdAt)
@@ -953,8 +947,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     List<TestCase> testCases = new ArrayList<>();
     testCases.add(originalTestCase);
     Measure originalMeasure =
-        measure
-            .toBuilder()
+        measure.toBuilder()
             .model(ModelType.QI_CORE.getValue())
             .cqlLibraryName("Test1CQLLibraryName")
             .testCases(testCases)
@@ -1026,8 +1019,7 @@ public class TestCaseServiceTest implements ResourceUtil {
   public void testUpdateTestCasePreventsModificationOfCreatedByFields() {
     Instant createdAt = Instant.now().minus(300, ChronoUnit.SECONDS);
     TestCase originalTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdAt(createdAt)
             .createdBy("test.user5")
             .lastModifiedAt(createdAt)
@@ -1039,8 +1031,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findMeasureById(anyString())).thenReturn(originalMeasure);
 
     TestCase updatingTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdBy("Nobody")
             .createdAt(Instant.now())
             .title("UpdatedTitle")
@@ -1084,8 +1075,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .save(any(Measure.class));
 
     TestCase upsertingTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdBy("Nobody")
             .createdAt(Instant.now())
             .title("UpdatedTitle")
@@ -1109,8 +1099,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertNotNull(savedMeasure.getTestCases());
     assertEquals(1, savedMeasure.getTestCases().size());
     TestCase expectedTestCase =
-        upsertingTestCase
-            .toBuilder()
+        upsertingTestCase.toBuilder()
             .hapiOperationOutcome(
                 HapiOperationOutcome.builder()
                     .code(500)
@@ -1130,8 +1119,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .save(any(Measure.class));
 
     TestCase upsertingTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdBy("Nobody")
             .createdAt(Instant.now())
             .title("UpdatedTitle")
@@ -1157,8 +1145,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertEquals(1, savedMeasure.getTestCases().size());
 
     TestCase expectedTestCase =
-        updatedTestCase
-            .toBuilder()
+        updatedTestCase.toBuilder()
             .hapiOperationOutcome(
                 HapiOperationOutcome.builder()
                     .code(500)
@@ -1181,8 +1168,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .save(any(Measure.class));
 
     TestCase upsertingTestCase =
-        testCase
-            .toBuilder()
+        testCase.toBuilder()
             .createdBy("Nobody")
             .createdAt(Instant.now())
             .title("UpdatedTitle")
@@ -1209,8 +1195,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertEquals(otherExistingTC, savedMeasure.getTestCases().get(0));
 
     TestCase expectedTestCase =
-        updatedTestCase
-            .toBuilder()
+        updatedTestCase.toBuilder()
             .hapiOperationOutcome(
                 HapiOperationOutcome.builder()
                     .code(500)

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -22,8 +22,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -601,8 +599,7 @@ public class VersionServiceTest {
     ReviewMetaData reviewMetaData =
         ReviewMetaData.builder().approvalDate(today).lastReviewDate(today).build();
     Measure versionedCopy =
-        versionedMeasure
-            .toBuilder()
+        versionedMeasure.toBuilder()
             .id("2")
             .versionId("13-13-13-13")
             .measureName("Test")
@@ -610,8 +607,7 @@ public class VersionServiceTest {
             .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
             .testCases(
                 List.of(
-                    testCase
-                        .toBuilder()
+                    testCase.toBuilder()
                         .id(ObjectId.get().toString())
                         .groupPopulations(List.of(clonedTestCaseGroupPopulation))
                         .build()))
@@ -665,8 +661,7 @@ public class VersionServiceTest {
     ReviewMetaData reviewMetaData =
         ReviewMetaData.builder().approvalDate(today).lastReviewDate(today).build();
     Measure versionedCopy =
-        versionedMeasure
-            .toBuilder()
+        versionedMeasure.toBuilder()
             .id("2")
             .versionId("13-13-13-13")
             .measureName("Test")

--- a/src/test/java/cms/gov/madie/measure/utils/MeasureUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/MeasureUtilTest.java
@@ -802,8 +802,7 @@ class MeasureUtilTest {
             .measurementPeriodEnd(new Date())
             .build();
     final Measure changed =
-        original
-            .toBuilder()
+        original.toBuilder()
             .measurementPeriodStart(Date.from(Instant.now().minus(5, ChronoUnit.DAYS)))
             .build();
     boolean output = measureUtil.isMeasurementPeriodChanged(changed, original);
@@ -818,8 +817,7 @@ class MeasureUtilTest {
             .measurementPeriodEnd(new Date())
             .build();
     final Measure changed =
-        original
-            .toBuilder()
+        original.toBuilder()
             .measurementPeriodEnd(Date.from(Instant.now().plus(5, ChronoUnit.DAYS)))
             .build();
     boolean output = measureUtil.isMeasurementPeriodChanged(changed, original);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6524](https://jira.cms.gov/browse/MAT-6524)
(Optional) Related Tickets:

### Summary

Re-add observations to the target population list when the measure's population criteria has observations.

Also:
- Formatter: Replace googleformatter-maven-plugin with spotify's fmt-maven-plugin set to google style. 
  - Previous formatter would error out on newer java syntax, notably text blocks and switch arrow syntax.
- Checkstyle: Ignore empty lines and comments when checking for maximum method length.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
