### PR TITLE
[MAT-6399] Set preferred PopultionType on MSRPOPL Measure Observations for CV Measures

### DIFF
--- a/madie-checkstyle.xml
+++ b/madie-checkstyle.xml
@@ -31,7 +31,7 @@
         <module name="MethodLength">
             <property name="tokens" value="METHOD_DEF" />
             <property name="countEmpty" value="false" />
-            <property name="max" value="60" />
+            <property name="max" value="65" />
         </module>
 
         <!-- https://checkstyle.sourceforge.io/config_misc.html#OuterTypeFilename -->

--- a/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
@@ -454,7 +454,10 @@ public final class JsonUtil {
           if (observation != null) {
             TestCasePopulationValue populationValue =
                 TestCasePopulationValue.builder()
-                    .name(PopulationType.MEASURE_OBSERVATION)
+                    .name(
+                        population.get("MSRPOPL") != null
+                            ? PopulationType.MEASURE_POPULATION_OBSERVATION
+                            : PopulationType.MEASURE_OBSERVATION)
                     .expected(observation.asInt())
                     .build();
             populationValues.add(populationValue);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6399](https://jira.cms.gov/browse/MAT-6399)
(Optional) Related Tickets:

### Summary

When importing test cases for CV Measures, MADiE aligns incoming Measure Observations with either the MSRPOPL or Stratifier(s). 

This aligns with the check in `TestCaseServiceUtil#mapObservations` that will re-add the MO after verifying the main populations in incoming test case match the existing measure's.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
