### PR TITLE
[MAT-6519] Import QDM Test Cases with Multiple Population Criteria

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -517,7 +517,7 @@ public class TestCaseService {
             testCaseServiceUtil.assignStratificationValuesQdm(testCaseGroupPopulations, groups);
       }
 
-      // See if the main populations from the measure population criteria and the incoming test case match.
+      // Compare main populations from the measure pop criteria against incoming test case.
       // Check includes Stratifications and excludes Observations.
       boolean matched =
           testCaseServiceUtil.matchCriteriaGroups(testCaseGroupPopulations, groups, newTestCase);

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -508,17 +508,19 @@ public class TestCaseService {
       List<TestCaseGroupPopulation> testCaseGroupPopulations =
           getTestCaseGroupPopulationsFromImportRequest(
               model, testCaseImportRequest.getJson(), measure);
+
       List<Group> groups = testCaseServiceUtil.getGroupsWithValidPopulations(measure.getGroups());
-      // See if the main populations (non-observation and strats) match between the measure's and
-      // the incoming test case's pop criteria.
-      boolean matched =
-          testCaseServiceUtil.matchCriteriaGroups(testCaseGroupPopulations, groups, newTestCase);
 
       // Ignore stratifications for QICore
-      if (matched && ModelType.QDM_5_6.getValue().equalsIgnoreCase(model)) {
-        testCaseServiceUtil.assignStratificationValuesQdm(
-            testCaseGroupPopulations, newTestCase, groups.get(0).getPopulationBasis());
+      if (ModelType.QDM_5_6.getValue().equalsIgnoreCase(model)) {
+        testCaseGroupPopulations =
+            testCaseServiceUtil.assignStratificationValuesQdm(testCaseGroupPopulations, groups);
       }
+
+      // See if the main populations from the measure population criteria and the incoming test case match.
+      // Check includes Stratifications and excludes Observations.
+      boolean matched =
+          testCaseServiceUtil.matchCriteriaGroups(testCaseGroupPopulations, groups, newTestCase);
 
       String warningMessage = null;
       if (!matched) {
@@ -580,20 +582,6 @@ public class TestCaseService {
       testCaseGroupPopulations = JsonUtil.getTestCaseGroupPopulationsQdm(json, measure);
     }
     return testCaseGroupPopulations;
-  }
-
-  protected void assignObservationAndStratificationValuesForQdm(
-      boolean matched,
-      String model,
-      List<TestCaseGroupPopulation> testCaseGroupPopulations,
-      TestCase newTestCase,
-      List<Group> groups) {
-    if (matched && ModelType.QDM_5_6.getValue().equalsIgnoreCase(model)) {
-      testCaseServiceUtil.assignStratificationValuesQdm(
-          testCaseGroupPopulations, newTestCase, groups.get(0).getPopulationBasis());
-      testCaseServiceUtil.assignObservationValues(
-          newTestCase, testCaseGroupPopulations, groups.get(0).getPopulationBasis());
-    }
   }
 
   private TestCaseImportOutcome updateTestCaseJsonAndSaveTestCase(

--- a/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
@@ -376,20 +376,7 @@ public final class JsonUtil {
         groupPopulations.add(groupPopulation);
       }
     }
-    List<TestCaseGroupPopulation> groupPopulationsCombined = new ArrayList<>();
-    if (!CollectionUtils.isEmpty(groupPopulations)) {
-      TestCaseGroupPopulation testCaseGroupPopulation = TestCaseGroupPopulation.builder().build();
-      for (TestCaseGroupPopulation groupPopulation : groupPopulations) {
-        if (!CollectionUtils.isEmpty(groupPopulation.getPopulationValues())) {
-          testCaseGroupPopulation.setPopulationValues(groupPopulation.getPopulationValues());
-        } else if (!CollectionUtils.isEmpty(groupPopulation.getStratificationValues())) {
-          testCaseGroupPopulation.setStratificationValues(
-              groupPopulation.getStratificationValues());
-        }
-      }
-      groupPopulationsCombined.add(testCaseGroupPopulation);
-    }
-    return groupPopulationsCombined;
+    return groupPopulations;
   }
 
   private static void handlePopulationValues(

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -46,24 +46,26 @@ public class TestCaseServiceUtil {
           PopulationType.NUMERATOR_EXCLUSION,
           PopulationType.DENOMINATOR_EXCEPTION);
 
+  /**
+   * Filter out populations that are not associated with a definition.
+   *
+   * @param originalGroups Target measure's Population Criteria.
+   * @return New List with populations associated with definitions.
+   */
   public List<Group> getGroupsWithValidPopulations(List<Group> originalGroups) {
-    List<Group> changedGroups = null;
-    if (!isEmpty(originalGroups)) {
-      changedGroups = new ArrayList<>();
-      for (Group group : originalGroups) {
-        if (!isEmpty(group.getPopulations())) {
-          List<Population> changedPopulations = new ArrayList<>();
-          for (Population population : group.getPopulations()) {
-            if (!StringUtils.isBlank(population.getDefinition())) {
-              changedPopulations.add(population);
-            }
-          }
-          group.setPopulations(changedPopulations);
-        }
-        changedGroups.add(group);
+    if (isEmpty(originalGroups)) {
+      return null;
+    }
+    List<Group> groups = new ArrayList<>(originalGroups);
+
+    for (Group group : groups) {
+      if (isNotEmpty(group.getPopulations())) {
+        List<Population> pops = new ArrayList<>(group.getPopulations());
+        pops.removeIf(pop -> StringUtils.isBlank(pop.getDefinition()));
+        group.setPopulations(pops);
       }
     }
-    return changedGroups;
+    return groups;
   }
 
   // match criteria groups from MeasureReport in imported json file

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -123,7 +123,7 @@ public class TestCaseServiceUtil {
    * This function modifies input parameters!
    *
    * @param group Existing Measure Population Criteria
-   * @param nonObsAndStratPopulations Population Criteria members excluding observations.
+   * @param nonObsPopulations Population Criteria members excluding observations.
    * @param measureGroupNumber
    * @param finalGroupPopulations Finalized list of Population Criteria populations.
    * @param newTestCase WIP Test Case from imported data
@@ -133,7 +133,7 @@ public class TestCaseServiceUtil {
    */
   private boolean mapPopulationValues(
       Group group,
-      List<TestCaseGroupPopulation> nonObsAndStratPopulations,
+      List<TestCaseGroupPopulation> nonObsPopulations,
       int measureGroupNumber,
       List<TestCaseGroupPopulation> finalGroupPopulations,
       TestCase newTestCase,
@@ -151,7 +151,7 @@ public class TestCaseServiceUtil {
       matchedNumber =
           assignPopulationValues(
               population,
-              nonObsAndStratPopulations,
+              nonObsPopulations,
               measureGroupNumber,
               groupPopulationIndex,
               matchedNumber,

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -159,7 +159,6 @@ public class TestCaseServiceUtil {
               populationValues,
               groupPopulation);
     }
-
     if (matchedNumber == group.getPopulations().size()) {
       // if group has observations and some existed on test case, add them back in
       List<TestCasePopulationValue> observationPopVals =
@@ -315,7 +314,7 @@ public class TestCaseServiceUtil {
 
   private Object getPopulationExpected(
       String populationBasis, TestCasePopulationValue populationValue) {
-    Object expected = null;
+    Object expected;
     if (populationBasis != null && populationBasis.equalsIgnoreCase("boolean")) {
       String originalValue = populationValue.getExpected().toString();
       if (originalValue.equalsIgnoreCase("1")) {
@@ -336,7 +335,7 @@ public class TestCaseServiceUtil {
     if (!isEmpty(testCaseGroupPopulations)) {
       for (TestCaseGroupPopulation groupPopulation : testCaseGroupPopulations) {
         List<TestCasePopulationValue> revisedPopulationValues = null;
-        if (CollectionUtils.isNotEmpty(groupPopulation.getPopulationValues())) {
+        if (isNotEmpty(groupPopulation.getPopulationValues())) {
           revisedPopulationValues =
               groupPopulation.getPopulationValues().stream()
                   .filter(
@@ -363,7 +362,7 @@ public class TestCaseServiceUtil {
 
     List<TestCasePopulationValue> combinedPopulationValues = new ArrayList<>();
     combinedPopulationValues.addAll(currentPopulationValues);
-    if (!CollectionUtils.isEmpty(observationPopulations)) {
+    if (!isEmpty(observationPopulations)) {
       combinedPopulationValues.addAll(
           convertPopulationValues(observationPopulations, populationBasis));
     }
@@ -376,7 +375,7 @@ public class TestCaseServiceUtil {
   private List<TestCasePopulationValue> convertPopulationValues(
       List<TestCasePopulationValue> observationValues, String populationBasis) {
     List<TestCasePopulationValue> observationPopulationValues = new ArrayList<>();
-    if (!CollectionUtils.isEmpty(observationValues)) {
+    if (!isEmpty(observationValues)) {
       for (TestCasePopulationValue observationvalue : observationValues) {
         TestCasePopulationValue populationValue =
             TestCasePopulationValue.builder()
@@ -392,8 +391,8 @@ public class TestCaseServiceUtil {
 
   protected List<TestCasePopulationValue> getObservationPopulations(
       List<TestCaseGroupPopulation> testCaseGroupPopulations) {
-    if (!CollectionUtils.isEmpty(testCaseGroupPopulations)
-        && !CollectionUtils.isEmpty(testCaseGroupPopulations.get(0).getPopulationValues())) {
+    if (!isEmpty(testCaseGroupPopulations)
+        && !isEmpty(testCaseGroupPopulations.get(0).getPopulationValues())) {
       return testCaseGroupPopulations.get(0).getPopulationValues().stream()
           .filter(populationValue -> populationValue.getName().toCode().contains("observation"))
           .toList();

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -259,6 +259,8 @@ public class TestCaseServiceUtil {
       }
       populationValues.add(populationValue);
       groupPopulation.setPopulationValues(populationValues);
+      groupPopulation.setStratificationValues(
+          testCaseGroupPopulations.get(measureGroupNumber).getStratificationValues());
     }
     return matchedNumber;
   }

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -37,6 +37,7 @@ public class TestCaseServiceUtil {
           PopulationType.INITIAL_POPULATION,
           PopulationType.MEASURE_POPULATION,
           PopulationType.MEASURE_POPULATION_OBSERVATION,
+          PopulationType.MEASURE_OBSERVATION,
           PopulationType.MEASURE_POPULATION_EXCLUSION,
           PopulationType.DENOMINATOR,
           PopulationType.DENOMINATOR_OBSERVATION,

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -285,12 +285,12 @@ public class TestCaseServiceUtil {
             .map(group -> group.getStratificationValues().get(0))
             .toList();
 
-    // Mismatch between target and import Stratification, don't set Strat expected values
+    // Mismatch between target and import Stratification, don't set any expected values
     boolean measureHasStrats =
         measureGroups.stream().allMatch(group -> isNotEmpty(group.getStratifications()));
     if ((measureHasStrats && isEmpty(stratification))
         || (!measureHasStrats && isNotEmpty(stratification))) {
-      return new ArrayList<>(populationCriteria);
+      return null;
     }
 
     if (measureGroups.size() > 1 && isNotEmpty(stratification)) {
@@ -306,9 +306,9 @@ public class TestCaseServiceUtil {
           }
         } while (!stratificationQueue.isEmpty());
       } catch (NoSuchElementException e) {
-        // Import Strat count doesn't align with measure group Strat count, don't set expected
+        // Import Strat count doesn't align with measure group Strat count, don't set any expected
         // values.
-        populationCriteria.forEach(popCrit -> popCrit.setStratificationValues(new ArrayList<>()));
+        return null;
       }
     } else {
       // Single group, go ahead and assign all strats.

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -514,6 +514,281 @@ public class TestCaseServiceUtilTest {
   }
 
   @Test
+  public void testAssignStratificationValuesUnevenPopulationCriteriaQdm() {
+    // Measure Groups
+    Group group1 =
+        Group.builder()
+            .id("testGroupId1")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population3, population4))
+            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build()))
+            .build();
+
+    Group group2 =
+        Group.builder()
+            .id("testGroupId2")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population4))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+    List<Group> measureGroups = new ArrayList<>();
+    measureGroups.add(group1);
+    measureGroups.add(group2);
+
+    // Imported Strat Populations
+    TestCaseStratificationValue stratValue1 =
+        TestCaseStratificationValue.builder().name("Strata-1").expected(1).build();
+    stratValue1.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(1).build()));
+
+    TestCaseStratificationValue stratValue2 =
+        TestCaseStratificationValue.builder().name("Strata-2").expected(0).build();
+    stratValue2.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build()));
+
+    TestCaseGroupPopulation stratPopCriteria1 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria3 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria4 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+
+    // Imported Populations
+    List<TestCaseGroupPopulation> importedGroups = new ArrayList<>();
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build(),
+                    TestCasePopulationValue.builder().expected(1).build()))
+            .build());
+
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build()))
+            .build());
+
+    importedGroups.add(stratPopCriteria1);
+    importedGroups.add(stratPopCriteria3);
+    importedGroups.add(stratPopCriteria4);
+
+    List<TestCaseGroupPopulation> testCaseGroups =
+        testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
+
+    assertEquals(2, testCaseGroups.size());
+    assertThat(testCaseGroups.get(0).getStratificationValues(), not(empty()));
+    assertThat(testCaseGroups.get(1).getStratificationValues(), not(empty()));
+
+    List<TestCaseStratificationValue> finalStratValues1 =
+        testCaseGroups.get(0).getStratificationValues();
+    assertThat(finalStratValues1.size(), is(1));
+    assertThat(finalStratValues1.get(0).getExpected(), is(1));
+
+    List<TestCaseStratificationValue> finalStratValues2 =
+        testCaseGroups.get(1).getStratificationValues();
+    assertThat(finalStratValues2.size(), is(2));
+    assertThat(finalStratValues2.get(0).getExpected(), is(1));
+    assertThat(finalStratValues2.get(1).getExpected(), is(0));
+  }
+
+  @Test
+  public void testAssignStratificationValuesQdmMoreImportStratsThanMeasureStrats() {
+    // Measure Groups
+    Group group1 =
+        Group.builder()
+            .id("testGroupId1")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population3, population4))
+            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build()))
+            .build();
+
+    Group group2 =
+        Group.builder()
+            .id("testGroupId2")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population4))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+    List<Group> measureGroups = new ArrayList<>();
+    measureGroups.add(group1);
+    measureGroups.add(group2);
+
+    // Imported Strat Populations
+    TestCaseStratificationValue stratValue1 =
+        TestCaseStratificationValue.builder().name("Strata-1").expected(1).build();
+    stratValue1.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(1).build()));
+
+    TestCaseStratificationValue stratValue2 =
+        TestCaseStratificationValue.builder().name("Strata-2").expected(0).build();
+    stratValue2.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build()));
+
+    TestCaseGroupPopulation stratPopCriteria1 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria2 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+    TestCaseGroupPopulation stratPopCriteria3 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria4 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+
+    // Imported Populations
+    List<TestCaseGroupPopulation> importedGroups = new ArrayList<>();
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build(),
+                    TestCasePopulationValue.builder().expected(1).build()))
+            .build());
+
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build()))
+            .build());
+
+    importedGroups.add(stratPopCriteria1);
+    importedGroups.add(stratPopCriteria2);
+    importedGroups.add(stratPopCriteria3);
+    importedGroups.add(stratPopCriteria4);
+
+    List<TestCaseGroupPopulation> testCaseGroups =
+        testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
+
+    assertEquals(2, testCaseGroups.size());
+    assertThat(testCaseGroups.get(0).getStratificationValues(), empty());
+    assertThat(testCaseGroups.get(1).getStratificationValues(), empty());
+  }
+
+  @Test
+  public void testAssignStratificationValuesQdmMoreMeasureStratsThanImportStrats() {
+    // Measure Groups
+    Group group1 =
+        Group.builder()
+            .id("testGroupId1")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population3, population4))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+
+    Group group2 =
+        Group.builder()
+            .id("testGroupId2")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population4))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+    List<Group> measureGroups = new ArrayList<>();
+    measureGroups.add(group1);
+    measureGroups.add(group2);
+
+    // Imported Strat Populations
+    TestCaseStratificationValue stratValue1 =
+        TestCaseStratificationValue.builder().name("Strata-1").expected(1).build();
+    stratValue1.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(1).build()));
+
+    TestCaseStratificationValue stratValue2 =
+        TestCaseStratificationValue.builder().name("Strata-2").expected(0).build();
+    stratValue2.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build()));
+
+    TestCaseGroupPopulation stratPopCriteria1 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria3 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+
+    // Imported Populations
+    List<TestCaseGroupPopulation> importedGroups = new ArrayList<>();
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build(),
+                    TestCasePopulationValue.builder().expected(1).build()))
+            .build());
+
+    importedGroups.add(
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build()))
+            .build());
+
+    importedGroups.add(stratPopCriteria1);
+    importedGroups.add(stratPopCriteria3);
+
+    List<TestCaseGroupPopulation> testCaseGroups =
+        testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
+
+    assertEquals(2, testCaseGroups.size());
+    assertThat(testCaseGroups.get(0).getStratificationValues(), empty());
+    assertThat(testCaseGroups.get(1).getStratificationValues(), empty());
+  }
+
+  @Test
   public void testAssignStratificationValuesQdmEmpty() {
     // Measure Group
     Group group =
@@ -536,7 +811,7 @@ public class TestCaseServiceUtilTest {
 
     List<TestCaseGroupPopulation> testCaseGroups =
         testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
-    assertThat(testCaseGroups.get(0).getStratificationValues(), empty());
+    assertThat(testCaseGroups.get(0).getStratificationValues(), nullValue());
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -408,6 +408,97 @@ public class TestCaseServiceUtilTest {
   }
 
   @Test
+  public void testAssignStratificationValuesMultiPopulationCriteriaQdm() {
+    // Measure Groups
+    Group group1 =
+        Group.builder()
+            .id("testGroupId1")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population3, population4))
+            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build(),
+                Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+
+    Group group2 =
+        Group.builder()
+            .id("testGroupId2")
+            .scoring(MeasureScoring.PROPORTION.name())
+            .populationBasis("Boolean")
+            .populations(List.of(population1, population2, population4))
+            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build(),
+                Stratification.builder().cqlDefinition("def2").build()))
+            .build();
+    List<Group> measureGroups = new ArrayList<>();
+    measureGroups.add(group1);
+    measureGroups.add(group2);
+
+    // Imported Strat Populations
+    TestCaseStratificationValue stratValue1 =
+        TestCaseStratificationValue.builder().name("Strata-1").expected(1).build();
+    stratValue1.setPopulationValues(List.of(
+        TestCasePopulationValue.builder().expected(1).build(),
+        TestCasePopulationValue.builder().expected(1).build(),
+        TestCasePopulationValue.builder().expected(0).build(),
+        TestCasePopulationValue.builder().expected(1).build()));
+
+    TestCaseStratificationValue stratValue2 =
+        TestCaseStratificationValue.builder().name("Strata-2").expected(0).build();
+    stratValue2.setPopulationValues(List.of(
+        TestCasePopulationValue.builder().expected(0).build(),
+        TestCasePopulationValue.builder().expected(0).build(),
+        TestCasePopulationValue.builder().expected(0).build(),
+        TestCasePopulationValue.builder().expected(0).build()));
+
+    TestCaseGroupPopulation stratPopCriteria1 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria2 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+    TestCaseGroupPopulation stratPopCriteria3 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria4 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+
+    // Imported Populations
+    List<TestCaseGroupPopulation> importedGroups = new ArrayList<>();
+    importedGroups.add(
+        TestCaseGroupPopulation.builder().populationValues(
+            List.of(
+                TestCasePopulationValue.builder().expected(1).build(),
+                TestCasePopulationValue.builder().expected(1).build(),
+                TestCasePopulationValue.builder().expected(0).build(),
+                TestCasePopulationValue.builder().expected(1).build())
+        ).build());
+
+    importedGroups.add(
+        TestCaseGroupPopulation.builder().populationValues(
+            List.of(
+                TestCasePopulationValue.builder().expected(1).build(),
+                TestCasePopulationValue.builder().expected(1).build(),
+                TestCasePopulationValue.builder().expected(1).build(),
+                TestCasePopulationValue.builder().expected(0).build())
+        ).build());
+
+    importedGroups.add(stratPopCriteria1);
+    importedGroups.add(stratPopCriteria2);
+    importedGroups.add(stratPopCriteria3);
+    importedGroups.add(stratPopCriteria4);
+
+    List<TestCaseGroupPopulation> testCaseGroups =
+        testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
+
+    assertEquals(2, testCaseGroups.size());
+    assertThat(testCaseGroups.get(0).getStratificationValues(), not(empty()));
+    assertThat(testCaseGroups.get(1).getStratificationValues(), not(empty()));
+
+    List<TestCaseStratificationValue> finalStratValues1 = testCaseGroups.get(0).getStratificationValues();
+    assertThat(finalStratValues1.size(), is(2));
+    assertThat(finalStratValues1.get(0).getExpected(), is(1));
+    assertThat(finalStratValues1.get(1).getExpected(), is(0));
+
+    List<TestCaseStratificationValue> finalStratValues2 = testCaseGroups.get(1).getStratificationValues();
+    assertThat(finalStratValues2.size(), is(2));
+    assertThat(finalStratValues2.get(0).getExpected(), is(1));
+    assertThat(finalStratValues2.get(1).getExpected(), is(0));
+  }
+
+  @Test
   public void testAssignStratificationValuesQdmEmpty() {
     // Measure Group
     Group group =

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -402,7 +402,8 @@ public class TestCaseServiceUtilTest {
     assertEquals(1, testCaseGroups.size());
     assertThat(testCaseGroups.get(0).getStratificationValues(), not(empty()));
 
-    List<TestCaseStratificationValue> finalStratValues = testCaseGroups.get(0).getStratificationValues();
+    List<TestCaseStratificationValue> finalStratValues =
+        testCaseGroups.get(0).getStratificationValues();
     assertThat(finalStratValues.size(), is(1));
     assertThat(finalStratValues.get(0).getExpected(), is(1));
   }
@@ -416,8 +417,10 @@ public class TestCaseServiceUtilTest {
             .scoring(MeasureScoring.PROPORTION.name())
             .populationBasis("Boolean")
             .populations(List.of(population1, population2, population3, population4))
-            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build(),
-                Stratification.builder().cqlDefinition("def2").build()))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
             .build();
 
     Group group2 =
@@ -426,8 +429,10 @@ public class TestCaseServiceUtilTest {
             .scoring(MeasureScoring.PROPORTION.name())
             .populationBasis("Boolean")
             .populations(List.of(population1, population2, population4))
-            .stratifications(List.of(Stratification.builder().cqlDefinition("def1").build(),
-                Stratification.builder().cqlDefinition("def2").build()))
+            .stratifications(
+                List.of(
+                    Stratification.builder().cqlDefinition("def1").build(),
+                    Stratification.builder().cqlDefinition("def2").build()))
             .build();
     List<Group> measureGroups = new ArrayList<>();
     measureGroups.add(group1);
@@ -436,44 +441,52 @@ public class TestCaseServiceUtilTest {
     // Imported Strat Populations
     TestCaseStratificationValue stratValue1 =
         TestCaseStratificationValue.builder().name("Strata-1").expected(1).build();
-    stratValue1.setPopulationValues(List.of(
-        TestCasePopulationValue.builder().expected(1).build(),
-        TestCasePopulationValue.builder().expected(1).build(),
-        TestCasePopulationValue.builder().expected(0).build(),
-        TestCasePopulationValue.builder().expected(1).build()));
+    stratValue1.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(1).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(1).build()));
 
     TestCaseStratificationValue stratValue2 =
         TestCaseStratificationValue.builder().name("Strata-2").expected(0).build();
-    stratValue2.setPopulationValues(List.of(
-        TestCasePopulationValue.builder().expected(0).build(),
-        TestCasePopulationValue.builder().expected(0).build(),
-        TestCasePopulationValue.builder().expected(0).build(),
-        TestCasePopulationValue.builder().expected(0).build()));
+    stratValue2.setPopulationValues(
+        List.of(
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build(),
+            TestCasePopulationValue.builder().expected(0).build()));
 
-    TestCaseGroupPopulation stratPopCriteria1 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
-    TestCaseGroupPopulation stratPopCriteria2 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
-    TestCaseGroupPopulation stratPopCriteria3 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
-    TestCaseGroupPopulation stratPopCriteria4 = TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+    TestCaseGroupPopulation stratPopCriteria1 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria2 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
+    TestCaseGroupPopulation stratPopCriteria3 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue1)).build();
+    TestCaseGroupPopulation stratPopCriteria4 =
+        TestCaseGroupPopulation.builder().stratificationValues(List.of(stratValue2)).build();
 
     // Imported Populations
     List<TestCaseGroupPopulation> importedGroups = new ArrayList<>();
     importedGroups.add(
-        TestCaseGroupPopulation.builder().populationValues(
-            List.of(
-                TestCasePopulationValue.builder().expected(1).build(),
-                TestCasePopulationValue.builder().expected(1).build(),
-                TestCasePopulationValue.builder().expected(0).build(),
-                TestCasePopulationValue.builder().expected(1).build())
-        ).build());
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build(),
+                    TestCasePopulationValue.builder().expected(1).build()))
+            .build());
 
     importedGroups.add(
-        TestCaseGroupPopulation.builder().populationValues(
-            List.of(
-                TestCasePopulationValue.builder().expected(1).build(),
-                TestCasePopulationValue.builder().expected(1).build(),
-                TestCasePopulationValue.builder().expected(1).build(),
-                TestCasePopulationValue.builder().expected(0).build())
-        ).build());
+        TestCaseGroupPopulation.builder()
+            .populationValues(
+                List.of(
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(1).build(),
+                    TestCasePopulationValue.builder().expected(0).build()))
+            .build());
 
     importedGroups.add(stratPopCriteria1);
     importedGroups.add(stratPopCriteria2);
@@ -487,12 +500,14 @@ public class TestCaseServiceUtilTest {
     assertThat(testCaseGroups.get(0).getStratificationValues(), not(empty()));
     assertThat(testCaseGroups.get(1).getStratificationValues(), not(empty()));
 
-    List<TestCaseStratificationValue> finalStratValues1 = testCaseGroups.get(0).getStratificationValues();
+    List<TestCaseStratificationValue> finalStratValues1 =
+        testCaseGroups.get(0).getStratificationValues();
     assertThat(finalStratValues1.size(), is(2));
     assertThat(finalStratValues1.get(0).getExpected(), is(1));
     assertThat(finalStratValues1.get(1).getExpected(), is(0));
 
-    List<TestCaseStratificationValue> finalStratValues2 = testCaseGroups.get(1).getStratificationValues();
+    List<TestCaseStratificationValue> finalStratValues2 =
+        testCaseGroups.get(1).getStratificationValues();
     assertThat(finalStratValues2.size(), is(2));
     assertThat(finalStratValues2.get(0).getExpected(), is(1));
     assertThat(finalStratValues2.get(1).getExpected(), is(0));

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -696,9 +696,7 @@ public class TestCaseServiceUtilTest {
     List<TestCaseGroupPopulation> testCaseGroups =
         testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
 
-    assertEquals(2, testCaseGroups.size());
-    assertThat(testCaseGroups.get(0).getStratificationValues(), empty());
-    assertThat(testCaseGroups.get(1).getStratificationValues(), empty());
+    assertNull(testCaseGroups);
   }
 
   @Test
@@ -783,9 +781,7 @@ public class TestCaseServiceUtilTest {
     List<TestCaseGroupPopulation> testCaseGroups =
         testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
 
-    assertEquals(2, testCaseGroups.size());
-    assertThat(testCaseGroups.get(0).getStratificationValues(), empty());
-    assertThat(testCaseGroups.get(1).getStratificationValues(), empty());
+    assertNull(testCaseGroups);
   }
 
   @Test
@@ -811,7 +807,7 @@ public class TestCaseServiceUtilTest {
 
     List<TestCaseGroupPopulation> testCaseGroups =
         testCaseServiceUtil.assignStratificationValuesQdm(importedGroups, measureGroups);
-    assertThat(testCaseGroups.get(0).getStratificationValues(), nullValue());
+    assertNull(testCaseGroups);
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6519](https://jira.cms.gov/browse/MAT-6519)
(Optional) Related Tickets:

### Summary

QDM only changes.

Updating how we match up the expected values from Bonnie Patient Imports with the MADiE measure's population criteria when there's multiple population criteria and stratifications. 

General flow:
<details>
<summary>1. Build a List`TestCaseGroupPopulation` entities from the `expectedValues` array in the Patient Import file...</summary>

   -  Each entry in the array is represented by a single `TestCaseGroupPopulation` object.
   -  If the array entry **does not** contain a `STRAT` value, then we consider it to be the core Populations (IPP, DENOM, Measure Population, various Observations, etc). 
   
      Core Populations are loaded into `TestCaseGroupPopultion.populationValues`.
   - If the array entry DOES contain `STRAT` value, then it is considered a Stratification, and is loaded into `TestCaseGroupPopulation.stratificationValues`. 
     
      In this case, `TestCaseGroupPopulation.populationValues` is empty.
   - At the end of this step will be a List of `TestCaseGroupPopulations` representing each entry in `expectedValues` array from the Import file. Some entries in the List will have empty `stratificationValues` and others will have empty `populationValues`.
</details>
<details>
<summary>2. Merge the Stratifications into their Population Criteria to match MADiE's data model...</summary>

   - MADiE keeps Stratifications and Populations as siblings, where as the import data is in series. This step is our best effort to align the two such that the resulting List of `TestCaseGroupPopulations` matches MADiE's Population Criteria data model.
   - At any time it is determined the measure's Stratifications and Import Stratifications won't align, **the method returns null** to signal a mismatch in Population Criteria.
   - The core of the matching is an attempt to assign each Import Stratification to a Population Criteria, based on the number of Stratifications configured for that Pop Criteria in the Measure, until the queue of Stratifications is empty.
   
     This accounts for cases where Pop Criteria N has X Stratifications and Pop Criteria P has X` Stratifications. In reality, for 2024 at least, it more common for Measures to have the same number of Stratifications on each Population Criteria.
</details>

3. (Existing) Check that the target Measure's Population Criteria matches the Import's `TestCaseGroupPopulations`:
    - If matched, set expected values.
    - Otherwise, save test cases without expected values and notify user.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
