### PR TITLE
MAT-7210: fetch MeasureSet during measure version operation as CMS ID…

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -157,10 +157,10 @@ public class VersionService {
 
   private Measure validateVersionOptions(
       String id, String versionType, String username, String accessToken) {
-    Measure measure =
-        measureRepository
-            .findById(id)
-            .orElseThrow(() -> new ResourceNotFoundException("Measure", id));
+    Measure measure = measureService.findMeasureById(id);
+    if (measure == null) {
+      throw new ResourceNotFoundException("Measure", id);
+    }
 
     if (!VERSION_TYPE_MAJOR.equalsIgnoreCase(versionType)
         && !VERSION_TYPE_MINOR.equalsIgnoreCase(versionType)

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -115,11 +115,13 @@ public class VersionServiceTest {
           .scoringUnit("test-scoring-unit")
           .build();
 
+  MeasureSet measureSet = MeasureSet.builder().measureSetId("MS123").cmsId(144).build();
+
   private final Instant today = Instant.now();
 
   @Test
   public void testCheckValidVersioningThrowsResourceNotFoundException() {
-    when(measureRepository.findById(anyString())).thenReturn(Optional.empty());
+    when(measureService.findMeasureById(anyString())).thenReturn(null);
 
     assertThrows(
         ResourceNotFoundException.class,
@@ -130,7 +132,7 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionThrowsResourceNotFoundException() {
-    when(measureRepository.findById(anyString())).thenReturn(Optional.empty());
+    when(measureService.findMeasureById(anyString())).thenReturn(null);
 
     assertThrows(
         ResourceNotFoundException.class,
@@ -139,8 +141,9 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionThrowsBadVersionRequestExceptionForInvalidVersionType() {
-    Measure existingMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    Measure existingMeasure =
+        Measure.builder().id("testMeasureId").createdBy("testUser").measureSet(measureSet).build();
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -152,7 +155,7 @@ public class VersionServiceTest {
   @Test
   public void testCheckValidVersioningThrowsBadVersionRequestExceptionForInvalidVersionType() {
     Measure existingMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -165,7 +168,7 @@ public class VersionServiceTest {
   public void testCheckValidVersioningThrowsUnauthorizedExceptionForNonOwner() {
     Measure existingMeasure =
         Measure.builder().id("testMeasureId").createdBy("anotherUser").build();
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
     doThrow(new UnauthorizedException("Measure", "testMeasureId", "testUser"))
         .when(measureService)
         .verifyAuthorization(anyString(), any(Measure.class));
@@ -180,8 +183,12 @@ public class VersionServiceTest {
   @Test
   public void testCreateVersionThrowsUnauthorizedExceptionForNonOwner() {
     Measure existingMeasure =
-        Measure.builder().id("testMeasureId").createdBy("anotherUser").build();
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+        Measure.builder()
+            .id("testMeasureId")
+            .createdBy("anotherUser")
+            .measureSet(measureSet)
+            .build();
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
     doThrow(new UnauthorizedException("Measure", "testMeasureId", "testUser"))
         .when(measureService)
         .verifyAuthorization(anyString(), any(Measure.class));
@@ -193,12 +200,13 @@ public class VersionServiceTest {
 
   @Test
   public void testCreateVersionThrowsBadVersionRequestExceptionForNonDraftMeasure() {
-    Measure existingMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
+    Measure existingMeasure =
+        Measure.builder().id("testMeasureId").createdBy("testUser").measureSet(measureSet).build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(false);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -206,13 +214,13 @@ public class VersionServiceTest {
   }
 
   @Test
-  public void testCCheckValidVersioningThrowsBadVersionRequestExceptionForNonDraftMeasure() {
+  public void testCheckValidVersioningThrowsBadVersionRequestExceptionForNonDraftMeasure() {
     Measure existingMeasure = Measure.builder().id("testMeasureId").createdBy("testUser").build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(false);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -224,12 +232,17 @@ public class VersionServiceTest {
   @Test
   public void testCreateVersionThrowsBadVersionRequestExceptionForCqlErrors() {
     Measure existingMeasure =
-        Measure.builder().id("testMeasureId").createdBy("testUser").cqlErrors(true).build();
+        Measure.builder()
+            .id("testMeasureId")
+            .createdBy("testUser")
+            .cqlErrors(true)
+            .measureSet(measureSet)
+            .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -244,7 +257,7 @@ public class VersionServiceTest {
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -261,12 +274,13 @@ public class VersionServiceTest {
             .createdBy("testUser")
             .cqlErrors(false)
             .cql("")
+            .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     assertThrows(
         BadVersionRequestException.class,
@@ -282,12 +296,13 @@ public class VersionServiceTest {
             .createdBy("testUser")
             .cqlErrors(false)
             .cql("test cql")
+            .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -312,7 +327,7 @@ public class VersionServiceTest {
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -339,7 +354,7 @@ public class VersionServiceTest {
     List<TestCase> testCases = List.of(TestCase.builder().validResource(false).build());
     existingMeasure.setTestCases(testCases);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -361,7 +376,7 @@ public class VersionServiceTest {
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -394,6 +409,7 @@ public class VersionServiceTest {
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
             .cql("library Test1CQLLib version '2.3.001'")
+            .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
@@ -401,7 +417,7 @@ public class VersionServiceTest {
     Version version = Version.builder().major(2).minor(3).revisionNumber(1).build();
     existingMeasure.setVersion(version);
 
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -452,6 +468,7 @@ public class VersionServiceTest {
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
             .cql("library Test1CQLLib version '2.3.001'")
+            .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
@@ -460,7 +477,7 @@ public class VersionServiceTest {
     existingMeasure.setVersion(version);
     List<TestCase> testCases = List.of(TestCase.builder().validResource(true).build());
     existingMeasure.setTestCases(testCases);
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);
@@ -513,6 +530,7 @@ public class VersionServiceTest {
             .measureSetId("testMeasureSetId")
             .createdBy("testUser")
             .cql("library Test1CQLLib version '2.3.001'")
+            .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
@@ -521,7 +539,7 @@ public class VersionServiceTest {
     existingMeasure.setVersion(version);
     List<TestCase> testCases = List.of(TestCase.builder().validResource(true).build());
     existingMeasure.setTestCases(testCases);
-    when(measureRepository.findById(anyString())).thenReturn(Optional.of(existingMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     ElmJson elmJson = ElmJson.builder().json(ELMJON_NO_ERROR).build();
     when(elmTranslatorClient.getElmJson(anyString(), anyString())).thenReturn(elmJson);


### PR DESCRIPTION


## MADiE PR

Jira Ticket: [MAT-7210](https://jira.cms.gov/browse/MAT-7210)
(Optional) Related Tickets:

### Summary
Switch from using `measureRepository.findById` to `measureService.findMeasureById` so that the measure set is also fetched and set onto the measure object prior to the version operation going through.
This is because CMS ID is now stored on measure set, and so measure set is needed when generating artifacts (like FHIR Bundle, HR, HQMF, etc) at version time.


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
