### PR TITLE
[MAT-7581] Ignore nulls value when serializing JSON for QDM Date Shift

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/QdmTestCaseShiftDatesService.java
+++ b/src/main/java/cms/gov/madie/measure/services/QdmTestCaseShiftDatesService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,7 +79,10 @@ public class QdmTestCaseShiftDatesService {
 
   private final TestCaseService testCaseService;
 
-  private ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+  private ObjectMapper mapper =
+      new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
   private static final String SEPARATOR = " |\n";
 
@@ -90,7 +94,7 @@ public class QdmTestCaseShiftDatesService {
   public TestCase shiftTestCaseDates(
       String measureId, String testCaseId, int shifted, String username, String accessToken) {
 
-    TestCase testCase = null;
+    TestCase testCase;
     List<TestCase> testCases = testCaseService.findTestCasesByMeasureId(measureId);
     if (CollectionUtils.isEmpty(testCases)) {
       throw new ResourceNotFoundException("TestCase", measureId);

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseShiftDatesServiceQdmTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseShiftDatesServiceQdmTest.java
@@ -150,11 +150,7 @@ public class TestCaseShiftDatesServiceQdmTest {
   @Test
   public void shiftTestCaseDatesNoDataElement() {
     String jsonInvalid =
-        "{\n"
-            + "  \"_id\" : \"66698bcec3b50c0000acc383\",\n"
-            + "  \"qdmVersion\" : \"5.6\",\n"
-            + "  \"dataElements\" : [ ]\n"
-            + "}";
+        "{\"_id\":\"66698bcec3b50c0000acc383\",\"qdmVersion\":\"5.6\",\"dataElements\":[]}";
     testCase.setJson(jsonInvalid);
     when(testCaseService.findTestCasesByMeasureId(anyString())).thenReturn(List.of(testCase));
 
@@ -164,6 +160,7 @@ public class TestCaseShiftDatesServiceQdmTest {
 
     assertNotNull(modified);
     assertFalse(modified.getJson().contains("2025"));
+    assertEquals(jsonInvalid, modified.getJson());
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7581](https://jira.cms.gov/browse/MAT-7581)
(Optional) Related Tickets:

### Summary

Jackson will, by default, include `null` values when serializing to JSON. As a result, the DOB was being saved as `null`, which is not supported by our frontend parser. 

Updating the Jackson ObjectMapper config used by the QDM Date Shift service to ignore nulls during serialization.

### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
