### PR TITLE
[MAT-7608] Configure Spring Data to allow dots in field names

### DIFF
--- a/src/main/java/cms/gov/madie/measure/config/MeasureMongoConfig.java
+++ b/src/main/java/cms/gov/madie/measure/config/MeasureMongoConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
-import org.springframework.data.mongodb.core.convert.AbstractMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
@@ -34,10 +33,14 @@ public class MeasureMongoConfig {
   public MongoConverter mongoConverter() throws Exception {
     DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory());
 
-    MongoConverter mongoConverter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+    MappingMongoConverter mongoConverter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+
+    // Allow for dots in Mongo field names.
+    // This knowingly affects only the cqlMeataData.codeSystemMap used by the Saved Codes UI.
+    mongoConverter.preserveMapKeys(true);
 
     // customized converter
-    ((AbstractMongoConverter) mongoConverter)
+    mongoConverter
         .setCustomConversions(
             new MongoCustomConversions(
                 Arrays.asList(new VersionConverter(), new StringOrganizationConverter())));


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7608](https://jira.cms.gov/browse/MAT-7608)
(Optional) Related Tickets:

### Summary

In general, Mongo does not like dots in field names as dots represent pathing (measure.name, for example). Since some Codes contain periods and we want to use those codes as Mongo field names in `cqlMetaData.codeSystemMap`, we need to configure the `MappingMongoConverter` to permit dots in Map structures.

See https://docs.spring.io/spring-data/mongodb/reference/mongodb/mapping/mapping.html#_special_field_names

#### Code containing dot in Mongo
![Screenshot 2024-09-04 at 4 26 17 PM](https://github.com/user-attachments/assets/c1743678-ef56-4254-8e06-db0877a1fb7e)

#### API Resposne
![Screenshot 2024-09-04 at 4 25 52 PM](https://github.com/user-attachments/assets/d9085a64-23d3-4a42-908c-8e90f0525e6f)

#### CQL Editor Save
![Screenshot 2024-09-04 at 4 25 12 PM](https://github.com/user-attachments/assets/81acb611-3fb2-48c6-b11a-120ab9213ad7)
##### honk 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
