### PR TITLE
MAT-7688: Reset the Test Case Number Sequence when All Test Cases are Deleted

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseSequenceRepository.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseSequenceRepository.java
@@ -1,0 +1,6 @@
+package cms.gov.madie.measure.repositories;
+
+import gov.cms.madie.models.measure.TestCaseSequence;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TestCaseSequenceRepository extends MongoRepository<TestCaseSequence, String> {}

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseSequenceService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseSequenceService.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.repositories.TestCaseSequenceRepository;
 import gov.cms.madie.models.measure.TestCaseSequence;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +9,7 @@ import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.springframework.data.mongodb.core.FindAndModifyOptions.options;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -18,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 @AllArgsConstructor
 public class TestCaseSequenceService {
   private MongoOperations mongoOperations;
+  private TestCaseSequenceRepository sequenceRepository;
 
   public int generateSequence(String measureId) {
     TestCaseSequence counter =
@@ -27,5 +30,14 @@ public class TestCaseSequenceService {
             options().returnNew(true).upsert(true),
             TestCaseSequence.class);
     return Objects.isNull(counter) ? 1 : counter.getSequence();
+  }
+
+  public void resetSequence(String measureId) {
+    Optional<TestCaseSequence> sequence = sequenceRepository.findById(measureId);
+    sequence.ifPresent(
+        testCaseSequence -> {
+          sequenceRepository.delete(testCaseSequence);
+          log.info("Reset sequence for test cases for measure [{}]", measureId);
+        });
   }
 }

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -384,6 +384,10 @@ public class TestCaseService {
         testCaseId,
         measureId);
     measureRepository.save(measure);
+    if (isEmpty(remainingTestCases)
+        && appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_ID)) {
+      sequenceService.resetSequence(measureId);
+    }
     return "Test case deleted successfully: " + testCaseId;
   }
 
@@ -409,6 +413,10 @@ public class TestCaseService {
     measure.setTestCases(remainingTestCases);
     measureRepository.save(measure);
 
+    if (appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_ID)) {
+      sequenceService.resetSequence(measureId);
+    }
+
     List<String> notDeletedTestCases =
         testCaseIds.stream()
             .filter(
@@ -420,7 +428,7 @@ public class TestCaseService {
           username,
           String.join(", ", notDeletedTestCases),
           measureId);
-      return "Succesfully deleted provided test cases except [ "
+      return "Successfully deleted provided test cases except [ "
           + String.join(", ", notDeletedTestCases)
           + " ]";
     }
@@ -429,7 +437,7 @@ public class TestCaseService {
         username,
         String.join(", ", testCaseIds),
         measureId);
-    return "Succesfully deleted provided test cases";
+    return "Successfully deleted provided test cases";
   }
 
   /**

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseSequenceServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseSequenceServiceTest.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.repositories.TestCaseSequenceRepository;
 import gov.cms.madie.models.measure.TestCaseSequence;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,23 +12,43 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TestCaseSequenceServiceTest {
   @Mock MongoOperations mongoOperations;
+  @Mock TestCaseSequenceRepository testCaseSequenceRepository;
 
   @InjectMocks TestCaseSequenceService testCaseSequenceService;
 
   @Test
   void generateSequence() {
-
     when(mongoOperations.findAndModify(
             any(Query.class), any(UpdateDefinition.class), any(FindAndModifyOptions.class), any()))
-        .thenReturn(TestCaseSequence.builder().sequence(1).build());
+        .thenReturn(TestCaseSequence.builder().sequence(100).build());
+    var result = testCaseSequenceService.generateSequence("measureId");
+    assertEquals(100, result);
+  }
+
+  @Test
+  void generateNewSequence() {
+    when(mongoOperations.findAndModify(
+            any(Query.class), any(UpdateDefinition.class), any(FindAndModifyOptions.class), any()))
+        .thenReturn(null);
     var result = testCaseSequenceService.generateSequence("measureId");
     assertEquals(1, result);
+  }
+
+  @Test
+  void resetSequence() {
+    TestCaseSequence sequence = TestCaseSequence.builder().sequence(1).build();
+    when(testCaseSequenceRepository.findById(anyString())).thenReturn(Optional.of(sequence));
+    testCaseSequenceService.resetSequence("measureId");
+    verify(testCaseSequenceRepository, times(1)).delete(sequence);
   }
 }


### PR DESCRIPTION


Signed-off-by: Joseph Kotanchik <joseph.kotanchik@semanticbits.com>

## MADiE PR

Jira Ticket: [MAT-7688](https://jira.cms.gov/browse/MAT-7688)
(Optional) Related Tickets:

### Summary

Whenever we go from 1 or more test cases to 0 test cases, either via Delete All or Delete the solitary test case, delete the associated document (using measureId) from the TestCaseSequence mongo collection to reset the measure's test case number sequence.

Dependent on the TestCaseID feature flag.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
