### PR TITLE
MAT-7961: Trim the eCQM Abbr Title when used in an export filename.

### DIFF
--- a/src/main/java/cms/gov/madie/measure/utils/ExportFileNamesUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/ExportFileNamesUtil.java
@@ -6,12 +6,12 @@ public class ExportFileNamesUtil {
 
   public static String getExportFileName(Measure measure) {
     if (measure.getModel().startsWith("QI-Core")) {
-      return measure.getEcqmTitle() + "-v" + measure.getVersion() + "-FHIR";
+      return measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-FHIR";
     }
-    return measure.getEcqmTitle() + "-v" + measure.getVersion() + "-" + measure.getModel();
+    return measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-" + measure.getModel();
   }
 
   public static String getTestCaseExportZipName(Measure measure) {
-    return measure.getEcqmTitle() + "-v" + measure.getVersion().toString() + "-TestCases";
+    return measure.getEcqmTitle().trim() + "-v" + measure.getVersion().toString() + "-TestCases";
   }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7961](https://jira.cms.gov/browse/MAT-7961)
(Optional) Related Tickets:

### Summary

Trim excess leading and trailing whitespace from the eCQM Abbreviated title when it is used in a filename.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
