### PR TITLE
[MAT-8183] QICore Test Case Import: Start Stratification Naming at 1

### DIFF
--- a/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/JsonUtil.java
@@ -260,7 +260,8 @@ public final class JsonUtil {
     String stratId = stratification.get("id").toString().replace("\"", "");
     // We need to match up the stratifications to the groups and group
     // population...
-    String stratName = "Strata-" + stratCount;
+    int stratDisplayCounter = stratCount + 1;
+    String stratName = "Strata " + stratDisplayCounter;
     ArrayNode stratums = (ArrayNode) stratification.get("stratum");
 
     List<JsonNode> stratumsList =

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -349,20 +349,12 @@ public class TestCaseServiceUtil {
     // Break up single list of pop values and strats into separate lists
     List<TestCaseGroupPopulation> populationCriteria =
         testCaseGroupPopulations.stream()
-            .filter(
-                group -> {
-                  return isNotEmpty(group.getPopulationValues());
-                })
+            .filter(group -> isNotEmpty(group.getPopulationValues()))
             .toList();
 
     List<TestCaseStratificationValue> stratification =
         testCaseGroupPopulations.stream()
-            .filter(
-                group -> {
-                  return isNotEmpty(group.getStratificationValues());
-                })
-            // Assumes there cannot be more than 1 strat in each incoming expected value obj
-            // .map(group -> group.getStratificationValues().get(0))
+            .filter(group -> isNotEmpty(group.getStratificationValues()))
             // (GAK MAT-8064 Why???  The QICore Test case can have a single population with multiple
             // stratification results)
             .flatMap(group -> group.getStratificationValues().stream())

--- a/src/test/java/cms/gov/madie/measure/utils/JsonUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/JsonUtilTest.java
@@ -424,6 +424,13 @@ public class JsonUtilTest implements ResourceUtil {
     List<TestCaseGroupPopulation> testCaseGroupPopulations =
         JsonUtil.getTestCaseGroupPopulationsFromMeasureReport(jsonWithStrat, true);
     assertThat(testCaseGroupPopulations.size(), is(equalTo(1)));
+    assertThat(testCaseGroupPopulations.get(0).getStratificationValues().size(), is(equalTo(2)));
+    assertThat(
+        testCaseGroupPopulations.get(0).getStratificationValues().get(0).getName(),
+        is(equalTo("Strata 1")));
+    assertThat(
+        testCaseGroupPopulations.get(0).getStratificationValues().get(1).getName(),
+        is(equalTo("Strata 2")));
   }
 
   @Test
@@ -434,6 +441,13 @@ public class JsonUtilTest implements ResourceUtil {
     List<TestCaseGroupPopulation> testCaseGroupPopulations =
         JsonUtil.getTestCaseGroupPopulationsFromMeasureReport(jsonWithStrat, true);
     assertThat(testCaseGroupPopulations.size(), is(equalTo(1)));
+    assertThat(testCaseGroupPopulations.get(0).getStratificationValues().size(), is(equalTo(2)));
+    assertThat(
+        testCaseGroupPopulations.get(0).getStratificationValues().get(0).getName(),
+        is(equalTo("Strata 1")));
+    assertThat(
+        testCaseGroupPopulations.get(0).getStratificationValues().get(1).getName(),
+        is(equalTo("Strata 2")));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8183](https://jira.cms.gov/browse/MAT-8183)
(Optional) Related Tickets:

### Summary

Use natural number counters when forming the Stratification name during Test Case Import (QICore). Doing so mimics the naming scheme of new test cases, e.g. "Strata 1 Initial Population", "Strata 2 Initial Population", etc.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
