### PR TITLE
[MAT-8262] Assign target measure's Stratification IDs to copied Test Cases

### DIFF
--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -269,6 +269,7 @@ public class TestCaseServiceUtil {
         stratValues.stream()
             .forEach(
                 (stratValue) -> {
+                  // Match stratification's population values to target group
                   List<TestCasePopulationValue> popValues = stratValue.getPopulationValues();
                   if (isNotEmpty(popValues)) {
                     popValues.stream()
@@ -283,6 +284,15 @@ public class TestCaseServiceUtil {
                             });
                   }
                 });
+
+        // Assign target group's stratification IDs to incoming Stratification.
+        // Stratification order is assumed to match between Test Case & Measure Groups.
+        if (isNotEmpty(group.getStratifications())
+            && stratValues.size() == group.getStratifications().size()) {
+          for (int i = 0; i < stratValues.size(); i++) {
+            stratValues.get(i).setId(group.getStratifications().get(i).getId());
+          }
+        }
       }
       groupPopulation.setStratificationValues(stratValues);
     }

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
@@ -3169,4 +3169,126 @@ public class TestCaseServiceTest implements ResourceUtil {
 
     assertThat(targetMeasure.getTestCases().size(), is(2));
   }
+
+  @Test
+  void testCopyToAnotherMeasureWithMatchingStratifications() {
+    // Set-up
+    TestCase source =
+        testCase.deepCopy().toBuilder()
+            .groupPopulations(
+                List.of(
+                    TestCaseGroupPopulation.builder()
+                        .scoring(MeasureScoring.PROPORTION.toString())
+                        .populationBasis("boolean")
+                        .populationValues(
+                            List.of(
+                                TestCasePopulationValue.builder()
+                                    .name(PopulationType.INITIAL_POPULATION)
+                                    .expected(true)
+                                    .build(),
+                                TestCasePopulationValue.builder()
+                                    .name(PopulationType.DENOMINATOR)
+                                    .expected(true)
+                                    .build(),
+                                TestCasePopulationValue.builder()
+                                    .name(PopulationType.NUMERATOR)
+                                    .expected(true)
+                                    .build()))
+                        .stratificationValues(
+                            List.of(
+                                TestCaseStratificationValue.builder()
+                                    .id("source-strat-id")
+                                    .name("Strata 1")
+                                    .expected(true)
+                                    .build()))
+                        .build()))
+            .build();
+
+    Measure targetMeasure =
+        measure.toBuilder()
+            .groups(
+                List.of(
+                    Group.builder()
+                        .scoring(MeasureScoring.PROPORTION.toString())
+                        .populationBasis("boolean")
+                        .populations(
+                            List.of(
+                                Population.builder()
+                                    .name(PopulationType.INITIAL_POPULATION)
+                                    .definition("def")
+                                    .build(),
+                                Population.builder()
+                                    .name(PopulationType.DENOMINATOR)
+                                    .definition("def")
+                                    .build(),
+                                Population.builder()
+                                    .name(PopulationType.NUMERATOR)
+                                    .definition("def")
+                                    .build()))
+                        .stratifications(
+                            List.of(Stratification.builder().id("target-strat-id").build()))
+                        .build()))
+            .build();
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(targetMeasure));
+    when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
+    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+        .thenReturn(
+            ResponseEntity.ok(HapiOperationOutcome.builder().code(200).successful(true).build()));
+    doReturn(targetMeasure).when(measureRepository).save(any());
+
+    // Start with empty Test Case list on target measure
+    assertTrue(CollectionUtils.isEmpty(targetMeasure.getTestCases()));
+
+    // Copy single Test Case to target measure
+    CopyTestCaseResult result =
+        testCaseService.copyTestCasesToMeasure(
+            targetMeasure.getId(), List.of(source), "user.name", "accessToken");
+
+    // Verify source Test Case wasn't modified
+    assertTrue(
+        (Boolean) source.getGroupPopulations().get(0).getPopulationValues().get(0).getExpected());
+    assertThat(
+        source.getGroupPopulations().get(0).getStratificationValues().get(0).getId(),
+        is("source-strat-id"));
+
+    // Matching Population Criteria - verify copied Test Case has source Population Expectations.
+    assertThat(result.getCopiedTestCases().size(), equalTo(1));
+    assertFalse(result.getDidClearExpectedValues());
+    assertThat(
+        (Boolean)
+            result
+                .getCopiedTestCases()
+                .get(0)
+                .getGroupPopulations()
+                .get(0)
+                .getPopulationValues()
+                .get(0)
+                .getExpected(),
+        is(
+            (Boolean)
+                source.getGroupPopulations().get(0).getPopulationValues().get(0).getExpected()));
+
+    assertThat(
+        result
+            .getCopiedTestCases()
+            .get(0)
+            .getGroupPopulations()
+            .get(0)
+            .getStratificationValues()
+            .size(),
+        is(1));
+    assertThat(
+        result
+            .getCopiedTestCases()
+            .get(0)
+            .getGroupPopulations()
+            .get(0)
+            .getStratificationValues()
+            .get(0)
+            .getId(),
+        is("target-strat-id"));
+
+    // Verify target measure now has a single Test Case
+    assertThat(targetMeasure.getTestCases().size(), is(1));
+  }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8262](https://jira.cms.gov/browse/MAT-8262)
(Optional) Related Tickets:

### Summary

Assuming Stratifications are ordered consistently between Measure Groups and Test Case Groups, this will overwrite the source Measure's Stratification IDs on the duplicated Test Case's Groups with the target Measure's Stratification IDs.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
