### PR TITLE
[MAT-8049] Versioned Measures: Get Bundles with GridFS when not available in Export

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/BundleService.java
+++ b/src/main/java/cms/gov/madie/measure/services/BundleService.java
@@ -3,6 +3,7 @@ package cms.gov.madie.measure.services;
 import java.lang.reflect.InvocationTargetException;
 
 import cms.gov.madie.measure.dto.PackageDto;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 
@@ -51,7 +52,16 @@ public class BundleService {
       log.error("Export not available for versioned measure with id: {}", measure.getId());
       throw new BundleOperationException("Measure", measure.getId(), null);
     }
-    return export.getMeasureBundleJson();
+
+    if (StringUtils.isNotBlank(export.getMeasureBundleJson())) {
+      return export.getMeasureBundleJson();
+    }
+    if (StringUtils.isNotBlank(export.getMeasureBundleGridFsId())) {
+      return mongoGridFsService.findById(export.getMeasureBundleGridFsId());
+    }
+    log.error(
+        "Bundle with warnings is not available for versioned measure with id: {}", measure.getId());
+    throw new BundleOperationException("Measure", measure.getId(), null);
   }
 
   public PackageDto getMeasureExport(Measure measure, String accessToken) {

--- a/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
@@ -137,9 +137,21 @@ class BundleServiceTest implements ResourceUtil {
   }
 
   @Test
+  void testBundleMeasureReturnsBundleStringForVersionedMeasureWithGridFS() {
+    final String json = "{\"message\": \"GOOD JSON\"}";
+    Export export = Export.builder().measureId(measure.getId()).measureBundleGridFsId("gridFsId").build();
+    measure.getMeasureMetaData().setDraft(false);
+    when(exportRepository.findByMeasureId(anyString())).thenReturn(Optional.of(export));
+    when(mongoGridFsService.findById(anyString())).thenReturn(json);
+
+    String output = bundleService.bundleMeasure(measure, "Bearer TOKEN", null);
+    assertThat(output, is(equalTo(json)));
+  }
+
+  @Test
   void testBundleMeasureReturnsBundleStringForVersionedMeasureIfExportUnavailable() {
     measure.getMeasureMetaData().setDraft(false);
-    when(exportRepository.findByMeasureId(anyString())).thenReturn(Optional.ofNullable(null));
+    when(exportRepository.findByMeasureId(anyString())).thenReturn(Optional.empty());
 
     Exception ex =
         assertThrows(


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8049](https://jira.cms.gov/browse/MAT-8049)
(Optional) Related Tickets:

### Summary

General bundle retrieval for versioned measures will first try to retrieve the bundle is available in Export collection. If not available, next it will try to retrieve the bundle with warnings stored in GridFS. Finally, throws an error indicating no bundle available.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
