### PR TITLE
[MAT-8638] Improve async validation status query precision

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
@@ -26,10 +26,12 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
     query.addCriteria(
         Criteria.where("_id")
             .is(measureId)
-            .and("testCases._id")
-            .is(testCaseId)
-            .and("testCases.validationStatus")
-            .ne(TestCaseValidationStatus.PENDING.toString()));
+            .and("testCases")
+            .elemMatch(
+                Criteria.where("_id")
+                    .is(testCaseId)
+                    .and("validationStatus")
+                    .ne(TestCaseValidationStatus.PENDING.toString())));
 
     Update update = new Update();
     update.set("testCases.$.validationStatus", TestCaseValidationStatus.PENDING.toString());
@@ -41,10 +43,15 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
   @Override
   public Measure setValidationStatusToValidating(String testCaseId, String measureId, UUID taskId) {
     Query query = new Query();
-    query.addCriteria(Criteria.where("_id").is(measureId).and("testCases._id").is(testCaseId));
     query.addCriteria(
-        Criteria.where("testCases.validationStatus")
-            .is(TestCaseValidationStatus.PENDING.toString()));
+        Criteria.where("_id")
+            .is(measureId)
+            .and("testCases")
+            .elemMatch(
+                Criteria.where("_id")
+                    .is(testCaseId)
+                    .and("validationStatus")
+                    .is(TestCaseValidationStatus.PENDING.toString())));
 
     Update update = new Update();
     update.set("testCases.$.validationStatus", TestCaseValidationStatus.VALIDATING.toString());
@@ -75,12 +82,14 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
     query.addCriteria(
         Criteria.where("_id")
             .is(measureId)
-            .and("testCases._id")
-            .is(testCaseId)
-            .and("testCases.validationStatus")
-            .is(TestCaseValidationStatus.VALIDATING.toString())
-            .and("testCases.validationTaskId")
-            .is(taskId.toString()));
+            .and("testCases")
+            .elemMatch(
+                Criteria.where("_id")
+                    .is(testCaseId)
+                    .and("validationStatus")
+                    .is(TestCaseValidationStatus.VALIDATING.toString())
+                    .and("testCases.validationTaskId")
+                    .is(taskId.toString())));
 
     Update update = new Update();
     update.set(

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
@@ -87,10 +87,7 @@ public class TestCaseValidationService {
         taskId,
         Instant.now(),
         importExecutor.getQueueSize());
-    importExecutor.submit(
-        () -> {
-          validate(taskId, measureId, testCase, modelType, accessToken);
-        });
+    importExecutor.submit(() -> validate(taskId, measureId, testCase, modelType, accessToken));
   }
 
   void validate(
@@ -102,11 +99,7 @@ public class TestCaseValidationService {
     // TODO replace with decorator
     Instant startTime = Instant.now();
     log.info(
-        "TestCase Validation::execute::{}::{}::{}::{}",
-        submittedTestCase.getId(),
-        Thread.currentThread().getId(),
-        taskId,
-        startTime);
+        "TestCase Validation::execute::{}::{}::{}", submittedTestCase.getId(), taskId, startTime);
     Measure measure =
         measureRepository.setValidationStatusToValidating(
             submittedTestCase.getId(), measureId, taskId);
@@ -133,9 +126,10 @@ public class TestCaseValidationService {
           currentTestCase.getId(), measureId, taskId, validationOutcome);
       Instant stopTime = Instant.now();
       log.info(
-          "TestCase Validation::completed::{}::{}::{}::{}",
+          "TestCase Validation::completed::{}::{}::{}::{}::{}",
           currentTestCase.getId(),
           taskId,
+          stopTime,
           Duration.between(startTime, stopTime),
           saveExecutor.getQueueSize());
     } catch (Exception e) {
@@ -157,7 +151,7 @@ public class TestCaseValidationService {
     // If the measure is null, the test case has already has PENDING status.
     if (updatedMeasure == null) {
       log.info(
-          "Test Case with Id {} already in validation queue for Measure with Id {}",
+          "TestCase Validation::already pending::{}::measure::{}",
           testCase.getId(),
           measure.getId());
       return testCase;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8638](https://jira.cms.gov/browse/MAT-8638)
(Optional) Related Tickets:

### Summary

- MAT-8638: Use Mongo element selector ($) when querying for test case validation status. Otherwise, the first status found in the testCases array will be returned.
- MAT-8638: Adjust async validation logging entries to have a consistent prefix to make downstream parsing easier.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
