### PR TITLE
MAT-8920: Include subclass fields and exclude measureSet in measure findAndModify

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/MeasurePatchRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/MeasurePatchRepositoryImpl.java
@@ -1,7 +1,9 @@
 package cms.gov.madie.measure.repositories;
 
 import cms.gov.madie.measure.exceptions.InternalServerException;
+import gov.cms.madie.models.measure.FhirMeasure;
 import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.QdmMeasure;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Update;
@@ -24,7 +26,7 @@ public class MeasurePatchRepositoryImpl implements MeasurePatchRepository {
 
   @Override
   public Measure findAndModify(Measure updatedMeasure) {
-    List<String> excludedFields = Arrays.asList("testCases", "testCaseConfiguration");
+    List<String> excludedFields = Arrays.asList("testCases", "testCaseConfiguration", "measureSet", "elmXml");
     return findAndModify(updatedMeasure, excludedFields);
   }
 
@@ -32,23 +34,38 @@ public class MeasurePatchRepositoryImpl implements MeasurePatchRepository {
   public Measure findAndModify(Measure updatedMeasure, List<String> excludedFields) {
     Update patchUpdate = new Update();
 
-    for (Field field : Measure.class.getDeclaredFields()) {
-      if (!excludedFields.contains(field.getName())) {
-        field.setAccessible(true); // Allow access to private fields
-        try {
-          patchUpdate.set(field.getName(), field.get(updatedMeasure));
-        } catch (IllegalAccessException e) {
-          throw new InternalServerException(
-              "Failed to access Measure field during findAndModify Set: " + field.getName());
-        }
+    if (updatedMeasure instanceof QdmMeasure) {
+      for (Field field : QdmMeasure.class.getDeclaredFields()) {
+        addFieldToUpdate(updatedMeasure, excludedFields, field, patchUpdate);
+      }
+    } else if (updatedMeasure instanceof FhirMeasure) {
+      for (Field field : FhirMeasure.class.getDeclaredFields()) {
+        addFieldToUpdate(updatedMeasure, excludedFields, field, patchUpdate);
       }
     }
 
+    for (Field field : Measure.class.getDeclaredFields()) {
+      addFieldToUpdate(updatedMeasure, excludedFields, field, patchUpdate);
+    }
+
     return mongoOperations
-        .update(Measure.class)
-        .matching(query(where("_id").is(updatedMeasure.getId())))
-        .apply(patchUpdate)
-        .withOptions(FindAndModifyOptions.options().returnNew(true))
-        .findAndModifyValue();
+      .update(Measure.class)
+      .matching(query(where("_id").is(updatedMeasure.getId())))
+      .apply(patchUpdate)
+      .withOptions(FindAndModifyOptions.options().returnNew(true))
+      .findAndModifyValue();
+  }
+
+  private void addFieldToUpdate(
+    Measure updatedMeasure, List<String> excludedFields, Field field, Update patchUpdate) {
+    if (!excludedFields.contains(field.getName())) {
+      field.setAccessible(true); // Allow access to private fields
+      try {
+        patchUpdate.set(field.getName(), field.get(updatedMeasure));
+      } catch (IllegalAccessException e) {
+        throw new InternalServerException(
+          "Failed to access Measure field during findAndModify Set: " + field.getName());
+      }
+    }
   }
 }

--- a/src/main/java/cms/gov/madie/measure/repositories/MeasurePatchRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/MeasurePatchRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
@@ -32,6 +33,7 @@ public class MeasurePatchRepositoryImpl implements MeasurePatchRepository {
 
   @Override
   public Measure findAndModify(Measure updatedMeasure, List<String> excludedFields) {
+    Objects.requireNonNull(updatedMeasure.getMeasureSet(), "MeasureSet cannot be null on save.");
     Update patchUpdate = new Update();
 
     if (updatedMeasure instanceof QdmMeasure) {
@@ -48,12 +50,16 @@ public class MeasurePatchRepositoryImpl implements MeasurePatchRepository {
       addFieldToUpdate(updatedMeasure, excludedFields, field, patchUpdate);
     }
 
-    return mongoOperations
+    Measure savedMeasure = mongoOperations
       .update(Measure.class)
       .matching(query(where("_id").is(updatedMeasure.getId())))
       .apply(patchUpdate)
       .withOptions(FindAndModifyOptions.options().returnNew(true))
       .findAndModifyValue();
+    // Set measureSet field since it is transient and not included in the save.
+    assert savedMeasure != null;
+    savedMeasure.setMeasureSet(updatedMeasure.getMeasureSet());
+    return savedMeasure;
   }
 
   private void addFieldToUpdate(

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -302,6 +302,7 @@ public class MeasureService {
       QdmMeasure qdmExistingMeasure = (QdmMeasure) existingMeasure;
       QdmMeasure qdmUpdatingMeasure = (QdmMeasure) updatingMeasure;
 
+      //TODO MAT-8920: Move elsewhere, findAndModify will ignore changes to test cases.
       if (!StringUtils.equals(qdmExistingMeasure.getScoring(), qdmUpdatingMeasure.getScoring())
           || (qdmExistingMeasure.isPatientBasis() != qdmUpdatingMeasure.isPatientBasis())) {
         List<TestCase> updatedTestCases =


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8920](https://jira.cms.gov/browse/MAT-8920)
(Optional) Related Tickets:

### Summary

- **MAT-8920: Exclude Transient fields. Include QdmMeasure and FhirMeasure fields.**
- **MAT-8920: Set measureSet field on save result. MeasureSet isn't included in the save operation since it is transient but is required by the UI to verify measure access.**

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
