### PR TITLE
MAT-8920: Move Test Case side effect out of Measure Service

### DIFF
--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -4,19 +4,18 @@ import cms.gov.madie.measure.dto.*;
 import cms.gov.madie.measure.exceptions.*;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.repositories.MeasureSetRepository;
-import cms.gov.madie.measure.services.ActionLogService;
-import cms.gov.madie.measure.services.GroupService;
-import cms.gov.madie.measure.services.MeasureService;
-import cms.gov.madie.measure.services.MeasureSetService;
+import cms.gov.madie.measure.services.*;
 import gov.cms.madie.models.access.AclOperation;
 import gov.cms.madie.models.access.AclSpecification;
 import gov.cms.madie.models.common.ActionType;
+import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.OwnershipType;
 import gov.cms.madie.models.dto.LibraryUsage;
 import gov.cms.madie.models.measure.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,15 +25,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 @RestController
@@ -47,6 +44,7 @@ public class MeasureController {
   private final ActionLogService actionLogService;
   private final MeasureSetRepository measureSetRepository;
   private final MeasureSetService measureSetService;
+  private final TestCaseService testCaseService;
 
   @PostMapping("/measures/draftstatus")
   public ResponseEntity<Map<String, Boolean>> getDraftStatuses(
@@ -174,6 +172,26 @@ public class MeasureController {
         // delete
         if (!measure.isActive()) {
           measureService.verifyAuthorization(username, measure, null);
+        }
+
+        // clear testcase groups for qdm when scoring or patient basis is changed.
+        // for QDM, scoring and patient basis are present outside the group
+        // therefor we need to clear testcase groups while updating measure
+        if (existingMeasure.getModel().equalsIgnoreCase(ModelType.QDM_5_6.getValue())
+            && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
+          QdmMeasure qdmExistingMeasure = (QdmMeasure) existingMeasure;
+          QdmMeasure qdmUpdatingMeasure = (QdmMeasure) measure;
+
+          if (!StringUtils.equals(qdmExistingMeasure.getScoring(), qdmUpdatingMeasure.getScoring())
+              || (qdmExistingMeasure.isPatientBasis() != qdmUpdatingMeasure.isPatientBasis())) {
+            existingMeasure
+                .getTestCases()
+                .forEach(
+                    testcase -> {
+                      testcase.setGroupPopulations(new ArrayList<>());
+                      testCaseService.updateTestCase(testcase, id, username, accessToken);
+                    });
+          }
         }
       }
 

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -294,29 +294,6 @@ public class MeasureService {
       outputMeasure.setErrors(existingMeasure.getErrors());
     }
 
-    // clear testcase groups for qdm when scoring or patient basis is changed.
-    // for QDM, scoring and patient basis are present outside the group
-    // therefor we need to clear testcase groups while updating measure
-    if (outputMeasure.getModel().equalsIgnoreCase(ModelType.QDM_5_6.getValue())
-        && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
-      QdmMeasure qdmExistingMeasure = (QdmMeasure) existingMeasure;
-      QdmMeasure qdmUpdatingMeasure = (QdmMeasure) updatingMeasure;
-
-      // TODO MAT-8920: Move elsewhere, findAndModify will ignore changes to test cases.
-      if (!StringUtils.equals(qdmExistingMeasure.getScoring(), qdmUpdatingMeasure.getScoring())
-          || (qdmExistingMeasure.isPatientBasis() != qdmUpdatingMeasure.isPatientBasis())) {
-        List<TestCase> updatedTestCases =
-            existingMeasure.getTestCases().stream()
-                .map(
-                    testcase -> {
-                      testcase.setGroupPopulations(new ArrayList<>());
-                      return testcase;
-                    })
-                .collect(Collectors.toList());
-        outputMeasure.setTestCases(updatedTestCases);
-      }
-    }
-
     outputMeasure.getMeasureMetaData().setDraft(existingMeasure.getMeasureMetaData().isDraft());
     outputMeasure.setLastModifiedBy(username);
     outputMeasure.setLastModifiedAt(Instant.now());

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
@@ -1,40 +1,24 @@
 package cms.gov.madie.measure.resources;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Map;
-import java.util.HashMap;
-
+import cms.gov.madie.measure.SecurityConfig;
 import cms.gov.madie.measure.dto.MeasureListDTO;
 import cms.gov.madie.measure.dto.MeasureSearchCriteria;
 import cms.gov.madie.measure.dto.SharedUser;
-import cms.gov.madie.measure.services.MeasureSetService;
+import cms.gov.madie.measure.exceptions.InvalidReturnTypeException;
+import cms.gov.madie.measure.exceptions.InvalidVersionIdException;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.repositories.MeasureSetRepository;
+import cms.gov.madie.measure.services.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.madie.models.access.AclOperation;
 import gov.cms.madie.models.access.AclSpecification;
 import gov.cms.madie.models.access.RoleEnum;
+import gov.cms.madie.models.common.ActionType;
+import gov.cms.madie.models.common.ModelType;
+import gov.cms.madie.models.common.Organization;
 import gov.cms.madie.models.common.OwnershipType;
 import gov.cms.madie.models.dto.LibraryUsage;
 import gov.cms.madie.models.measure.*;
@@ -43,7 +27,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -52,38 +35,40 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.*;
 
-import cms.gov.madie.measure.SecurityConfig;
-import cms.gov.madie.measure.exceptions.InvalidReturnTypeException;
-import cms.gov.madie.measure.exceptions.InvalidVersionIdException;
-import cms.gov.madie.measure.repositories.MeasureRepository;
-import cms.gov.madie.measure.repositories.MeasureSetRepository;
-import cms.gov.madie.measure.services.ActionLogService;
-import cms.gov.madie.measure.services.GroupService;
-import cms.gov.madie.measure.services.MeasureService;
-import gov.cms.madie.models.common.ActionType;
-import gov.cms.madie.models.common.ModelType;
-import gov.cms.madie.models.common.Organization;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest({MeasureController.class})
 @ActiveProfiles("test")
 @Import(SecurityConfig.class)
 public class MeasureControllerMvcTest {
 
-  @MockBean private MeasureRepository measureRepository;
-  @MockBean private MeasureService measureService;
-  @MockBean private GroupService groupService;
-  @MockBean private ActionLogService actionLogService;
-  @MockBean private MeasureSetService measureSetService;
+  @MockitoBean private MeasureRepository measureRepository;
+  @MockitoBean private MeasureService measureService;
+  @MockitoBean private GroupService groupService;
+  @MockitoBean private ActionLogService actionLogService;
+  @MockitoBean private MeasureSetService measureSetService;
   @Autowired private MockMvc mockMvc;
-  @MockBean private MeasureSetRepository measureSetRepository;
+  @MockitoBean private MeasureSetRepository measureSetRepository;
+  @MockitoBean private TestCaseService testCaseService;
   @Captor private ArgumentCaptor<Measure> measureArgumentCaptor;
   @Captor private ArgumentCaptor<Measure> measureArgumentCaptor2;
 

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -8,15 +8,10 @@ import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.repositories.MeasureSetRepository;
-import cms.gov.madie.measure.services.ActionLogService;
-import cms.gov.madie.measure.services.GroupService;
-import cms.gov.madie.measure.services.MeasureService;
-import cms.gov.madie.measure.services.MeasureSetService;
+import cms.gov.madie.measure.services.*;
 import gov.cms.madie.models.access.AclSpecification;
 import gov.cms.madie.models.access.RoleEnum;
-import gov.cms.madie.models.common.ActionType;
-import gov.cms.madie.models.common.OwnershipType;
-import gov.cms.madie.models.common.Version;
+import gov.cms.madie.models.common.*;
 import gov.cms.madie.models.dto.LibraryUsage;
 import gov.cms.madie.models.measure.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +53,7 @@ class MeasureControllerTest {
   @Mock private GroupService groupService;
   @Mock private ActionLogService actionLogService;
   @Mock private MeasureSetRepository measureSetRepository;
+  @Mock private TestCaseService testCaseService;
   @InjectMocks private MeasureController controller;
 
   private Measure measure1;
@@ -72,6 +68,7 @@ class MeasureControllerTest {
   public void setUp() {
     measure1 =
         Measure.builder()
+            .model(ModelType.QI_CORE.toString())
             .active(true)
             .measureSetId("IDIDID")
             .measureName("MSR01")
@@ -975,5 +972,63 @@ class MeasureControllerTest {
     assertThat(result.get("ownedMeasures"), is(equalTo(5)));
     assertThat(result.get("sharedMeasures"), is(equalTo(3)));
     assertThat(result.get("allMeasures"), is(equalTo(10)));
+  }
+
+  @Test
+  public void testClearingTestCaseGroupPopulationValuesWhenScoringIsChangedForQDMMeasures() {
+    TestCaseGroupPopulation testCaseGroupPopulation =
+        TestCaseGroupPopulation.builder().groupId("groupId1").scoring("Cohort").build();
+
+    TestCase testCase =
+        TestCase.builder().id("testId1").groupPopulations(List.of(testCaseGroupPopulation)).build();
+
+    QdmMeasure original =
+        QdmMeasure.builder()
+            .cql("original cql here")
+            .model(ModelType.QDM_5_6.getValue())
+            .active(true)
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
+            .errors(List.of(MeasureErrorType.ERRORS_ELM_JSON))
+            .id("testId")
+            .createdBy("test.user")
+            .scoring(MeasureScoring.COHORT.toString())
+            .groups(null)
+            .testCases(List.of(testCase))
+            .patientBasis(false)
+            .build();
+
+    QdmMeasure updated =
+        original.toBuilder()
+            .cql("changed cql here")
+            .scoring(MeasureScoring.PROPORTION.toString())
+            .build();
+
+    Measure expected =
+        updated.toBuilder().error(MeasureErrorType.MISMATCH_CQL_POPULATION_RETURN_TYPES).build();
+
+    ArgumentCaptor<TestCase> saveTestCaseCaptor = ArgumentCaptor.forClass(TestCase.class);
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn("test.user");
+
+    when(measureService.updateMeasure(
+            any(Measure.class), anyString(), any(Measure.class), anyString()))
+        .thenReturn(expected);
+    when(measureService.findMeasureById(anyString()))
+        .thenReturn(
+            original.toBuilder()
+                .measureSet(MeasureSet.builder().owner("test.user").build())
+                .build());
+    doNothing().when(measureService).verifyAuthorization(anyString(), any(Measure.class));
+
+    Measure output =
+        controller.updateMeasure(updated.getId(), updated, principal, "Bearer TOKEN").getBody();
+    assertThat(output, is(notNullValue()));
+    assertThat(output, is(equalTo(expected)));
+    assertThat(output.getTestCases().get(0).getGroupPopulations(), is(equalTo(new ArrayList<>())));
+
+    verify(testCaseService, times(1))
+        .updateTestCase(saveTestCaseCaptor.capture(), anyString(), anyString(), anyString());
+    TestCase persisted = saveTestCaseCaptor.getValue();
+    assertThat(persisted, is(equalTo(expected.getTestCases().get(0))));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -45,7 +45,6 @@ import gov.cms.madie.models.dto.LibraryUsage;
 import gov.cms.madie.models.measure.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -1756,77 +1755,6 @@ public class MeasureServiceTest implements ResourceUtil {
     Exception ex =
         assertThrows(InvalidRequestException.class, () -> measureService.findLibraryUsage(null));
     assertThat(ex.getMessage(), is(equalTo("Please provide library name.")));
-  }
-
-  @Test
-  @Disabled // TODO MAT-8921
-  public void testClearingTestCaseGroupPopulationValuesWhenScoringIsChangedForQDMMeasures() {
-    TestCaseGroupPopulation testCaseGroupPopulation =
-        TestCaseGroupPopulation.builder()
-            .groupId("groupId1")
-            .scoring("Cohort")
-            .populationBasis("boolean")
-            .build();
-
-    TestCase testCase =
-        TestCase.builder()
-            .id("testId1")
-            .caseNumber(2)
-            .name("IPPPass")
-            .series("BloodPressure>124")
-            .createdBy("TestUser")
-            .lastModifiedBy("TestUser2")
-            .json("{\"resourceType\":\"Patient\"}")
-            .title("Test1")
-            .groupPopulations(List.of(testCaseGroupPopulation))
-            .build();
-
-    QdmMeasure original =
-        QdmMeasure.builder()
-            .cqlLibraryName("OriginalLibName")
-            .measureName("Measure1")
-            .versionId("VersionId")
-            .cql("original cql here")
-            .model(ModelType.QDM_5_6.getValue())
-            .measureMetaData(draftMeasureMetaData)
-            .errors(List.of(MeasureErrorType.ERRORS_ELM_JSON))
-            .measurementPeriodStart(Date.from(Instant.now().minus(38, ChronoUnit.DAYS)))
-            .measurementPeriodEnd(Date.from(Instant.now().minus(11, ChronoUnit.DAYS)))
-            .id("testId")
-            .scoring(MeasureScoring.COHORT.toString())
-            .groups(null)
-            .testCases(List.of(testCase))
-            .patientBasis(false)
-            .elmJson(elmJson)
-            .build();
-
-    QdmMeasure updated =
-        original.toBuilder()
-            .cql("changed cql here")
-            .scoring(MeasureScoring.PROPORTION.toString())
-            .build();
-    when(measureUtil.isCqlLibraryNameChanged(any(Measure.class), any(Measure.class)))
-        .thenReturn(false);
-    when(measureUtil.isMeasurementPeriodChanged(any(Measure.class), any(Measure.class)))
-        .thenReturn(false);
-    when(measureUtil.isMeasureCqlChanged(any(Measure.class), any(Measure.class))).thenReturn(true);
-    when(elmTranslatorClient.getElmJson(anyString(), anyString(), anyString()))
-        .thenReturn(ElmJson.builder().json("{\"library\": {}}").xml("<library></library>").build());
-    when(elmTranslatorClient.hasErrors(any(ElmJson.class))).thenReturn(false);
-
-    Measure expected =
-        updated.toBuilder().error(MeasureErrorType.MISMATCH_CQL_POPULATION_RETURN_TYPES).build();
-    when(measureUtil.validateAllMeasureDependencies(any(Measure.class))).thenReturn(expected);
-    when(measureRepository.save(any(Measure.class))).thenReturn(expected);
-
-    Measure output = measureService.updateMeasure(original, "User1", updated, "Access Token");
-    assertThat(output, is(notNullValue()));
-    assertThat(output, is(equalTo(expected)));
-    assertThat(output.getTestCases().get(0).getGroupPopulations(), is(equalTo(new ArrayList<>())));
-
-    verify(measureRepository, times(1)).save(measureArgumentCaptor.capture());
-    Measure persisted = measureArgumentCaptor.getValue();
-    assertThat(persisted, is(equalTo(expected)));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8920](https://jira.cms.gov/browse/MAT-8920)
(Optional) Related Tickets:

### Summary

As part of moving away from saving the update Measure document on each save, effects on measure updates on non-measure fields (namely Test Case) need to be handled outside of the Measure Service. Otherwise, they will be missed due to findAndModify not targeting those fields.

- MAT-8920: Test update: replace deprecated @MockBean with @MockitoBean per Spring's MockMvc Setup instructions.
- MAT-8920: Move test case side effect from measureUpdate out of Measure Service and into Controller.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
