### PR TITLE
MAT-9158: Additional options for Admin STU6 Test Case validation endpoint

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
@@ -160,12 +160,14 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
                     .is(taskId.toString())));
 
     Update update = new Update();
-    update.set(
-        "testCases.$.validationStatus",
-        validationResults.isSuccessful()
+    String validationResultStatus =
+        validationResults != null && validationResults.isSuccessful()
             ? TestCaseValidationStatus.VALID.toString()
-            : TestCaseValidationStatus.INVALID.toString());
-    update.set("testCases.$.validResource", validationResults.isSuccessful());
+            : TestCaseValidationStatus.INVALID.toString();
+    update.set(
+        "testCases.$.validationStatus", validationResultStatus
+        );
+    update.set("testCases.$.validResource", validationResults != null && validationResults.isSuccessful());
     update.set("testCases.$.hapiOperationOutcome", validationResults);
 
     return mongoOperations.findAndModify(query, update, RETURN_NEW_OPTIONS, Measure.class);

--- a/src/main/java/cms/gov/madie/measure/resources/AdminController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/AdminController.java
@@ -127,61 +127,119 @@ public class AdminController {
             .build());
   }
 
-  // This endpoint is used to reset the validation queue for QI Core v6 measures test cases
-  // that are in validating state
+  /**
+   * Reset/Populate the validation queue for QI Core v6 measures test cases. By default, retrieves
+   * all active draft QI Core v6 measures with test cases and places their test cases back on the
+   * validation queue if their status is PENDING or VALIDATING.
+   *
+   * <p>Optionally, can be forced to place all test cases back on the validation queue regardless of
+   * their current validation status by setting the 'force' parameter to true.
+   *
+   * <p>Validation requests generated via this endpoint will be processed via the import queue to
+   * avoid excessive load on the save queue.
+   *
+   * @param request Spring-ism.
+   * @param apiKey Admin API key value.
+   * @param principal Security principal.
+   * @param draftOnly (Optional, default=true) If true, only draft measures are considered. False
+   *     includes all active measures.
+   * @param force (Optional, default=false) If true, places all test cases from filtered STU6
+   *     Measures back on the validation queue regardless of their current validation status.
+   * @param excludeUsers (Optional) List of harpIds to exclude measures created by those users.
+   * @param measureIds (Optional) List of measureIds to specifically include. If provided, only
+   *     measures with these Ids are considered.
+   * @param accessToken Okta access token.
+   * @return Count of test cases placed back on the validation queue.
+   */
   @PutMapping("/measures/test-cases/restart-validation")
   @PreAuthorize("#request.getHeader('api-key') == #apiKey")
-  public void resetTestCaseValidationQueue(
+  public ResponseEntity<Integer> resetTestCaseValidationQueue(
       HttpServletRequest request,
       @Value("${admin-api-key}") String apiKey,
       Principal principal,
+      @RequestParam(name = "draftOnly", defaultValue = "true") boolean draftOnly,
+      @RequestParam(name = "force", defaultValue = "false") boolean force,
+      @RequestParam(name = "excludeUsers", required = false) List<String> excludeUsers,
+      @RequestParam(name = "measureIds", required = false) List<String> measureIds,
       @RequestHeader("Authorization") String accessToken) {
 
     log.info(
         "User [{}] - Starting admin task to place QI Core v6 testcases back on the validation queue",
         principal.getName());
-    List<Measure> measureList =
+    List<Measure> allQiCore6Measures =
         measureRepository.findAllByModel(ModelType.QI_CORE_6_0_0.getValue());
 
-    if (CollectionUtils.isNotEmpty(measureList)) {
-      measureList.forEach(
-          measure -> {
-            if (CollectionUtils.isNotEmpty(measure.getTestCases())) {
-              measure
-                  .getTestCases()
-                  .forEach(
-                      testCase -> {
-                        if (TestCaseValidationStatus.PENDING
-                            .toString()
-                            .equalsIgnoreCase(testCase.getValidationStatus())) {
-                          // Submit test case already in PENDING status
-                          testCaseValidationService.submitOnSaveValidationTask(
+    List<Measure> targetQiCore6Measures =
+        allQiCore6Measures.stream()
+            .filter(measure -> CollectionUtils.isNotEmpty(measure.getTestCases()))
+            .filter(
+                measure -> {
+                  if (draftOnly) {
+                    return measure.getMeasureMetaData().isDraft();
+                  }
+                  return true;
+                })
+            .filter(Measure::isActive)
+            .filter(
+                measure -> {
+                  if (CollectionUtils.isNotEmpty(excludeUsers)) {
+                    return excludeUsers.contains(measure.getCreatedBy());
+                  }
+                  return true;
+                })
+            .filter(
+                measure -> {
+                  if (CollectionUtils.isNotEmpty(measureIds)) {
+                    return measureIds.contains(measure.getId());
+                  }
+                  return true;
+                })
+            .toList();
+
+    if (CollectionUtils.isEmpty(targetQiCore6Measures)) {
+      return ResponseEntity.ok(0);
+    }
+
+    targetQiCore6Measures.forEach(
+        measure -> {
+          if (CollectionUtils.isNotEmpty(measure.getTestCases())) {
+            measure
+                .getTestCases()
+                .forEach(
+                    testCase -> {
+                      if (TestCaseValidationStatus.PENDING
+                          .toString()
+                          .equalsIgnoreCase(testCase.getValidationStatus())) {
+                        // Submit test case already in PENDING status
+                        testCaseValidationService.submitOnImportValidationTask(
+                            measure.getId(),
+                            testCase,
+                            accessToken,
+                            ModelType.valueOfName(measure.getModel()));
+                      } else if (force
+                          || TestCaseValidationStatus.VALIDATING
+                              .toString()
+                              .equalsIgnoreCase(testCase.getValidationStatus())) {
+                        Measure updatedMeasure =
+                            measureRepository.setValidationStatusToPending(
+                                testCase.getId(), measure.getId());
+                        if (updatedMeasure != null) {
+                          // submit the test case after updating its status
+                          testCaseValidationService.submitOnImportValidationTask(
                               measure.getId(),
                               testCase,
                               accessToken,
                               ModelType.valueOfName(measure.getModel()));
-                        } else if (TestCaseValidationStatus.VALIDATING
-                            .toString()
-                            .equalsIgnoreCase(testCase.getValidationStatus())) {
-                          Measure updatedMeasure =
-                              measureRepository.setValidationStatusToPending(
-                                  testCase.getId(), measure.getId());
-                          if (updatedMeasure != null) {
-                            // submit the test case after updating its status
-                            testCaseValidationService.submitOnSaveValidationTask(
-                                measure.getId(),
-                                testCase,
-                                accessToken,
-                                ModelType.valueOfName(measure.getModel()));
-                          }
                         }
-                      });
-            }
-          });
-      log.info(
-          "User [{}] - Successfully placed QI Core v6 test cases back on the validation queue",
-          principal.getName());
-    }
+                      }
+                    });
+          }
+        });
+    log.info(
+        "User [{}] - Successfully placed QI Core v6 test cases back on the validation queue",
+        principal.getName());
+    return ResponseEntity.ok(
+        targetQiCore6Measures.stream().map(Measure::getTestCases).mapToInt(Collection::size).sum());
   }
 
   @DeleteMapping("/measures/{id}")

--- a/src/main/java/cms/gov/madie/measure/resources/AdminController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/AdminController.java
@@ -166,9 +166,12 @@ public class AdminController {
     log.info(
         "User [{}] - Starting admin task to place QI Core v6 testcases back on the validation queue",
         principal.getName());
+    StopWatch timer = new StopWatch();
+    timer.start("Find All QI Core v6 Measures");
     List<Measure> allQiCore6Measures =
         measureRepository.findAllByModel(ModelType.QI_CORE_6_0_0.getValue());
-
+    timer.stop();
+    timer.start("Filter Measures");
     List<Measure> targetQiCore6Measures =
         allQiCore6Measures.stream()
             .filter(measure -> CollectionUtils.isNotEmpty(measure.getTestCases()))
@@ -195,11 +198,11 @@ public class AdminController {
                   return true;
                 })
             .toList();
-
+    timer.stop();
     if (CollectionUtils.isEmpty(targetQiCore6Measures)) {
       return ResponseEntity.ok(0);
     }
-
+    timer.start("Kickoff Test Case Validations");
     targetQiCore6Measures.forEach(
         measure -> {
           if (CollectionUtils.isNotEmpty(measure.getTestCases())) {
@@ -235,9 +238,11 @@ public class AdminController {
                     });
           }
         });
+    timer.stop();
     log.info(
         "User [{}] - Successfully placed QI Core v6 test cases back on the validation queue",
         principal.getName());
+    log.info("Admin::Test Case Validation::{}", timer.prettyPrint());
     return ResponseEntity.ok(
         targetQiCore6Measures.stream().map(Measure::getTestCases).mapToInt(Collection::size).sum());
   }

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
@@ -78,7 +78,7 @@ public class TestCaseValidationService {
     saveExecutor.submit(() -> validate(taskId, measureId, testCase, modelType, accessToken));
   }
 
-  void submitOnImportValidationTask(
+  public void submitOnImportValidationTask(
       String measureId, TestCase testCase, String accessToken, ModelType modelType) {
     UUID taskId = UUID.randomUUID();
     log.info(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,9 +59,9 @@ madie:
     cql-template-qdm56-url: ${CQL_TEMPLATE_QDM56_URL:https://madie-dev-static.s3.amazonaws.com/templates/QDM56_CQLTemplate.txt}
     cql-template-qicore600-url: ${CQL_TEMPLATE_QICORE600_URL:https://madie-dev-static.s3.amazonaws.com/templates/QICore600_CQLTemplate.txt}
   async:
-    core-pool-size: ${MADIE_ASYNC_CORE_POOL_SIZE:10}
-    queue-size: ${MADIE_ASYNC_QUEUE_SIZE:500}
-    max-pool-size: ${MADIE_ASYNC_MAX_POOL_SIZE:20}
+    core-pool-size: ${MADIE_ASYNC_CORE_POOL_SIZE:100}
+    queue-size: ${MADIE_ASYNC_QUEUE_SIZE:1500}
+    max-pool-size: ${MADIE_ASYNC_MAX_POOL_SIZE:200}
     shutdown-wait-seconds: ${MADIE_ASYNC_SHUTDOWN_WAIT_SECONDS:300}
 
 management:

--- a/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
@@ -816,6 +816,8 @@ public class AdminControllerMvcTest {
         Measure.builder()
             .id("M1")
             .model(ModelType.QI_CORE_6_0_0.getValue())
+            .active(true)
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
             .testCases(
                 List.of(
                     TestCase.builder()
@@ -852,7 +854,7 @@ public class AdminControllerMvcTest {
         .andExpect(status().isOk());
 
     verify(testCaseValidationService, times(1))
-        .submitOnSaveValidationTask(
+        .submitOnImportValidationTask(
             eq("M1"),
             eq(measure.getTestCases().get(0)),
             eq("test-okta"),
@@ -868,6 +870,8 @@ public class AdminControllerMvcTest {
         Measure.builder()
             .id("M1")
             .model(ModelType.QI_CORE_6_0_0.getValue())
+            .active(true)
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
             .testCases(
                 List.of(
                     TestCase.builder()
@@ -889,7 +893,7 @@ public class AdminControllerMvcTest {
         .andExpect(status().isOk());
 
     verify(testCaseValidationService, times(1))
-        .submitOnSaveValidationTask(
+        .submitOnImportValidationTask(
             eq("M1"), any(TestCase.class), eq("test-okta"), eq(ModelType.QI_CORE_6_0_0));
   }
 
@@ -900,6 +904,8 @@ public class AdminControllerMvcTest {
         Measure.builder()
             .id("M1")
             .model(ModelType.QI_CORE_6_0_0.getValue())
+            .active(true)
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
             .testCases(
                 List.of(
                     TestCase.builder()
@@ -921,7 +927,7 @@ public class AdminControllerMvcTest {
         .andExpect(status().isOk());
 
     verify(testCaseValidationService, never())
-        .submitOnSaveValidationTask(
+        .submitOnImportValidationTask(
             anyString(), any(TestCase.class), anyString(), any(ModelType.class));
   }
 
@@ -973,6 +979,8 @@ public class AdminControllerMvcTest {
         Measure.builder()
             .id("M1")
             .model(ModelType.QI_CORE_6_0_0.getValue())
+            .active(true)
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
             .testCases(
                 List.of(
                     TestCase.builder()
@@ -1018,13 +1026,13 @@ public class AdminControllerMvcTest {
         .andExpect(status().isOk());
 
     verify(testCaseValidationService, times(1))
-        .submitOnSaveValidationTask(
+        .submitOnImportValidationTask(
             eq("M1"),
             eq(measure.getTestCases().get(1)),
             eq("test-okta"),
             eq(ModelType.QI_CORE_6_0_0));
     verify(testCaseValidationService, never())
-        .submitOnSaveValidationTask(
+        .submitOnImportValidationTask(
             eq("M1"),
             eq(measure.getTestCases().get(2)),
             eq("test-okta"),


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9158](https://jira.cms.gov/browse/MAT-9158)
(Optional) Related Tickets:

### Summary

Add options to the restart-validations Admin API for additional use cases. Namely, forcing validation regardless of validation status and validation of test cases from specific measures.

Requests from this admin endpoint will now be loaded onto the import queue since it is expected to be loaded less frequently than the save queue. This will prevent users actively modifying test cases from having their requests enqueued behind requests from this endpoint.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
