### PR TITLE
MAT-8919: Prevent Deletion of Locked Test Cases

### DIFF
--- a/src/main/java/cms/gov/madie/measure/exceptions/LockNotObtainedException.java
+++ b/src/main/java/cms/gov/madie/measure/exceptions/LockNotObtainedException.java
@@ -1,10 +1,17 @@
 package cms.gov.madie.measure.exceptions;
 
+import lombok.Getter;
+
+import java.io.Serial;
+
+@Getter
 public class LockNotObtainedException extends RuntimeException {
 
-  private static final long serialVersionUID = 3773507296919206651L;
+  @Serial private static final long serialVersionUID = 3773507296919206651L;
 
   private static final String MESSAGE = "ID: %s, is not able to acquire lock, locked by: %s";
+
+  private String lockedBy;
 
   public LockNotObtainedException() {
     super("Lock is not obtained");
@@ -12,6 +19,7 @@ public class LockNotObtainedException extends RuntimeException {
 
   public LockNotObtainedException(String id, String lockedBy) {
     super(String.format(MESSAGE, id, lockedBy));
+    this.lockedBy = lockedBy;
   }
 
   public LockNotObtainedException(String message) {

--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepository.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepository.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 public interface TestCaseRepository {
   Measure addOrUpdateTestCase(String measureId, TestCase testCase);
 
+  Measure removeTestCase(String measureId, String testCaseId);
+
   Measure setValidationStatusToPending(String testCaseId, String measureId);
 
   Measure setValidationStatusToValidating(String testCaseId, String measureId, UUID taskId);

--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.repositories;
 
+import cms.gov.madie.measure.exceptions.InvalidIdException;
 import gov.cms.madie.models.measure.HapiOperationOutcome;
 import gov.cms.madie.models.measure.Measure;
 import gov.cms.madie.models.measure.TestCase;
@@ -58,8 +59,14 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
   @Override
   public Measure removeTestCase(String measureId, String testCaseId) {
     Query query = new Query(Criteria.where("_id").is(measureId));
-    Update update = new Update().pull("testCases", Query.query(Criteria.where("_id").is(testCaseId)));
-    return mongoOperations.findAndModify(query, update, RETURN_NEW_OPTIONS, Measure.class);
+    Update update =
+        new Update().pull("testCases", Query.query(Criteria.where("_id").is(testCaseId)));
+    Measure updatedMeasure =
+        mongoOperations.findAndModify(query, update, RETURN_NEW_OPTIONS, Measure.class);
+    if (updatedMeasure == null) {
+      throw new InvalidIdException("Test Case", "delete");
+    }
+    return updatedMeasure;
   }
 
   /**

--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
@@ -55,6 +55,13 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
     return updatedMeasure;
   }
 
+  @Override
+  public Measure removeTestCase(String measureId, String testCaseId) {
+    Query query = new Query(Criteria.where("_id").is(measureId));
+    Update update = new Update().pull("testCases", Query.query(Criteria.where("_id").is(testCaseId)));
+    return mongoOperations.findAndModify(query, update, RETURN_NEW_OPTIONS, Measure.class);
+  }
+
   /**
    * Sets the validation status of a specific TestCase within a Measure to PENDING. This only
    * applies if the current status is not already PENDING.

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -11,7 +11,6 @@ import cms.gov.madie.measure.utils.TestCaseServiceUtil;
 import gov.cms.madie.models.common.ModelType;
 import cms.gov.madie.measure.services.TestCaseService;
 import cms.gov.madie.measure.utils.ControllerUtil;
-import cms.gov.madie.measure.utils.UserInputSanitizeUtil;
 import gov.cms.madie.models.measure.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +24,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.*;
+
+import static cms.gov.madie.measure.utils.UserInputSanitizeUtil.sanitizeUserInput;
 
 @Slf4j
 @RestController
@@ -117,7 +118,8 @@ public class TestCaseController {
         measureId);
 
     return ResponseEntity.ok(
-        testCaseService.deleteTestCases(measureId, testCaseIds, principal.getName()));
+        testCaseService.deleteTestCases(
+            sanitizeUserInput(measureId), sanitizeUserInput(testCaseIds), principal.getName()));
   }
 
   @PutMapping(ControllerUtil.TEST_CASES + "/imports")
@@ -134,9 +136,9 @@ public class TestCaseController {
   }
 
   private TestCase sanitizeTestCase(TestCase testCase) {
-    testCase.setDescription(UserInputSanitizeUtil.sanitizeUserInput(testCase.getDescription()));
-    testCase.setTitle(UserInputSanitizeUtil.sanitizeUserInput(testCase.getTitle()));
-    testCase.setSeries(UserInputSanitizeUtil.sanitizeUserInput(testCase.getSeries()));
+    testCase.setDescription(sanitizeUserInput(testCase.getDescription()));
+    testCase.setTitle(sanitizeUserInput(testCase.getTitle()));
+    testCase.setSeries(sanitizeUserInput(testCase.getSeries()));
     return testCase;
   }
 

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseLockService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseLockService.java
@@ -63,7 +63,10 @@ public class TestCaseLockService {
     if (existingLock.isPresent()) {
       if (existingLock.get().getLockedBy().equals(userName)) {
         testCaseLockRepository.deleteByTestCaseId(testCaseId);
-        return LockInfo.builder().lockedId(existingLock.get().getTestCaseId()).isLocked(false).build();
+        return LockInfo.builder()
+            .lockedId(existingLock.get().getTestCaseId())
+            .isLocked(false)
+            .build();
       } else {
         return LockInfo.builder()
             .lockedId((existingLock.get().getTestCaseId()))

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseLockService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseLockService.java
@@ -1,26 +1,24 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.LockInfo;
+import cms.gov.madie.measure.exceptions.LockNotObtainedException;
+import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
+import cms.gov.madie.measure.locks.TestCaseLock;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.repositories.TestCaseLockRepository;
+import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.TestCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.springframework.dao.DuplicateKeyException;
-import org.springframework.stereotype.Service;
-
-import cms.gov.madie.measure.repositories.MeasureRepository;
-import cms.gov.madie.measure.repositories.TestCaseLockRepository;
-
-import gov.cms.madie.models.measure.Measure;
-import gov.cms.madie.models.measure.TestCase;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
-import cms.gov.madie.measure.locks.TestCaseLock;
-import cms.gov.madie.measure.dto.LockInfo;
 
 @Slf4j
 @Service
@@ -28,6 +26,14 @@ import cms.gov.madie.measure.dto.LockInfo;
 public class TestCaseLockService {
   private final MeasureRepository measureRepository;
   private final TestCaseLockRepository testCaseLockRepository;
+
+  public synchronized void lockTestCaseForUser(
+      String measureId, String testCaseId, String userName) {
+    LockInfo lockInfo = lockTestCase(measureId, testCaseId, userName);
+    if (!lockInfo.getLockedBy().equals(userName)) {
+      throw new LockNotObtainedException("", lockInfo.getLockedBy());
+    }
+  }
 
   public synchronized LockInfo lockTestCase(String measureId, String testCaseId, String userName) {
     validateMeasureAndTestCase(measureId, testCaseId);
@@ -57,7 +63,7 @@ public class TestCaseLockService {
     if (existingLock.isPresent()) {
       if (existingLock.get().getLockedBy().equals(userName)) {
         testCaseLockRepository.deleteByTestCaseId(testCaseId);
-        return LockInfo.builder().isLocked(false).build();
+        return LockInfo.builder().lockedId(existingLock.get().getTestCaseId()).isLocked(false).build();
       } else {
         return LockInfo.builder()
             .lockedId((existingLock.get().getTestCaseId()))
@@ -66,7 +72,7 @@ public class TestCaseLockService {
             .build();
       }
     }
-    return null;
+    return LockInfo.builder().lockedId(testCaseId).isLocked(false).build();
   }
 
   TestCase validateMeasureAndTestCase(String measureId, String testCaseId) {

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -371,7 +371,7 @@ public class TestCaseService {
   public List<TestCase> findTestCasesByMeasureId(String measureId) {
     return findActiveMeasureById(measureId).getTestCases();
   }
-  
+
   public String deleteTestCases(String measureId, List<String> testCaseIds, String username) {
     if (isEmpty(testCaseIds) || StringUtils.isBlank(measureId)) {
       log.info("Test case Ids or Measure Id is Empty");

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -10,6 +10,7 @@ import cms.gov.madie.measure.utils.TestCaseServiceUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
@@ -21,6 +22,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import static cms.gov.madie.measure.utils.JsonUtil.convertDateTimeToUTC;
+import static cms.gov.madie.measure.utils.TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning;
 import static java.util.stream.Collectors.*;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -204,8 +206,7 @@ public class TestCaseService {
         List<TestCase> validatedTestCases =
             updateTestCaseValidResourcesForMeasure(measure, accessToken);
         Map<String, TestCase> testCaseMap =
-            validatedTestCases.stream()
-                .collect(toMap(TestCase::getId, Function.identity()));
+            validatedTestCases.stream().collect(toMap(TestCase::getId, Function.identity()));
         reports.forEach(
             report ->
                 report.setCurrentValidResource(
@@ -373,7 +374,9 @@ public class TestCaseService {
   }
 
   public String deleteTestCases(String measureId, List<String> testCaseIds, String username) {
-    if (isEmpty(testCaseIds) || StringUtils.isBlank(measureId)) {
+    if (isEmpty(testCaseIds)
+        || StringUtils.isBlank(measureId)
+        || testCaseIds.stream().allMatch(StringUtils::isBlank)) {
       log.info("Test case Ids or Measure Id is Empty");
       throw new InvalidIdException("Test cases cannot be deleted, please contact the helpdesk");
     }
@@ -384,44 +387,64 @@ public class TestCaseService {
       throw new InvalidIdException(
           "Measure {} doesn't have any existing test cases to delete", measureId);
     }
-    TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(
+    checkIfAnyCreatedBeforeVersioning(
         measure.getTestCases(), testCaseIds, measure.getMeasureMetaData().isDraft());
+
     List<TestCase> testCasesToDelete =
         measure.getTestCases().stream().filter(tc -> testCaseIds.contains(tc.getId())).toList();
 
-    List<String> testCasesLockedByOtherUser = new ArrayList<>();
-    testCasesToDelete.forEach(testCase -> {
-      try {
-        testCaseLockService.lockTestCaseForUser(measureId, testCase.getId(), username);
-        measureRepository.removeTestCase(measureId, testCase.getId());
-        testCaseLockService.unlockTestCase(measureId, testCase.getId());
-      } catch(Exception e) {
-        testCasesLockedByOtherUser.add(testCase.getId());
-      }
-    });
+    List<String> testCaseIdsDeleted = new ArrayList<>();
+    List<String> testCaseIdsLockedByOtherUser = new ArrayList<>();
+    if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)) {
+      testCasesToDelete.forEach(
+          testCase -> {
+            try {
+              testCaseLockService.lockTestCaseForUser(measureId, testCase.getId(), username);
+              measureRepository.removeTestCase(measureId, testCase.getId());
+              testCaseIdsDeleted.add(testCase.getId());
+              testCaseLockService.unlockTestCase(measureId, testCase.getId());
+            } catch (LockNotObtainedException e) {
+              testCaseIdsLockedByOtherUser.add(testCase.getId());
+            } catch (InvalidIdException e) {
+              // no-op - this means the test case was not found in the measure
+            }
+          });
+    } else {
+      testCasesToDelete.forEach(
+          testCase -> {
+            measureRepository.removeTestCase(measureId, testCase.getId());
+            testCaseIdsDeleted.add(testCase.getId());
+          });
+    }
 
-    if (testCasesToDelete.size() == measure.getTestCases().size()) {
+    if (testCaseIdsDeleted.size() == measure.getTestCases().size()) {
       sequenceService.resetSequence(measureId);
     }
 
-    if (!isEmpty(testCasesLockedByOtherUser)) {
+    if (isEmpty(testCaseIdsLockedByOtherUser)) {
       log.info(
-          "User [{}] was unable to delete following test cases with Ids [{}] from measure [{}]",
+          "User [{}] deleted test cases with Ids [{}] from measure [{}]",
           username,
-          String.join(", ", testCasesLockedByOtherUser),
+          testCaseIds,
           measureId);
-      return "Successfully deleted provided test cases except [ "
-          + String.join(", ", testCasesLockedByOtherUser)
-          + " ]";
+      String successMessage =
+          "Successfully deleted test cases: " + String.join(", ", testCaseIdsDeleted);
+      if (testCaseIdsDeleted.size() == testCaseIds.size()) {
+        return successMessage;
+      }
+      return successMessage
+          + ", unable to delete "
+          + String.join(", ", CollectionUtils.removeAll(testCaseIds, testCaseIdsDeleted));
     }
+
     log.info(
-        "User [{}] has successfully deleted following test cases with Ids [{}] from measure [{}]. Test Cases with Ids [{}] were locked by another user and could not be deleted.",
+        "User [{}] deleted test cases with Ids {} from measure [{}]. "
+            + "Test Cases with Ids {} were locked by another user and could not be deleted.",
         username,
-        testCaseIds.stream().filter(testCaseId ->
-          !testCasesLockedByOtherUser.contains(testCaseId))
-          .collect(joining(",")), String.join(", ", testCasesLockedByOtherUser),
-        measureId);
-    return "Successfully deleted provided test cases";
+        String.join(", ", testCaseIdsDeleted),
+        measureId,
+        String.join(", ", testCaseIdsLockedByOtherUser));
+    throw new LockNotObtainedException(String.join(",", testCaseIdsLockedByOtherUser));
   }
 
   public CopyTestCaseResult copyTestCasesToMeasure(
@@ -483,7 +506,7 @@ public class TestCaseService {
     }
     return CopyTestCaseResult.builder()
         .copiedTestCases(copiedTestCases)
-        .didClearExpectedValues(clearedExpectedValues)
+        .didClearExpectedValues(Boolean.valueOf(clearedExpectedValues))
         .build();
   }
 

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -204,7 +204,8 @@ public class TestCaseService {
         List<TestCase> validatedTestCases =
             updateTestCaseValidResourcesForMeasure(measure, accessToken);
         Map<String, TestCase> testCaseMap =
-            validatedTestCases.stream().collect(toMap(TestCase::getId, Function.identity()));
+            validatedTestCases.stream()
+                .collect(toMap(TestCase::getId, Function.identity()));
         reports.forEach(
             report ->
                 report.setCurrentValidResource(
@@ -383,38 +384,42 @@ public class TestCaseService {
       throw new InvalidIdException(
           "Measure {} doesn't have any existing test cases to delete", measureId);
     }
-    TestCaseServiceUtil.checkIfDeletable(
+    TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(
         measure.getTestCases(), testCaseIds, measure.getMeasureMetaData().isDraft());
-    List<TestCase> deletedTestCases =
+    List<TestCase> testCasesToDelete =
         measure.getTestCases().stream().filter(tc -> testCaseIds.contains(tc.getId())).toList();
-    List<TestCase> remainingTestCases =
-        measure.getTestCases().stream().filter(tc -> !testCaseIds.contains(tc.getId())).toList();
-    measure.setTestCases(remainingTestCases);
-    measureRepository.save(measure);
 
-    if (isEmpty(measure.getTestCases())) {
+    List<String> testCasesLockedByOtherUser = new ArrayList<>();
+    testCasesToDelete.forEach(testCase -> {
+      try {
+        testCaseLockService.lockTestCaseForUser(measureId, testCase.getId(), username);
+        measureRepository.removeTestCase(measureId, testCase.getId());
+        testCaseLockService.unlockTestCase(measureId, testCase.getId());
+      } catch(Exception e) {
+        testCasesLockedByOtherUser.add(testCase.getId());
+      }
+    });
+
+    if (testCasesToDelete.size() == measure.getTestCases().size()) {
       sequenceService.resetSequence(measureId);
     }
 
-    List<String> notDeletedTestCases =
-        testCaseIds.stream()
-            .filter(
-                id -> deletedTestCases.stream().noneMatch(tc -> tc.getId().equalsIgnoreCase(id)))
-            .toList();
-    if (!isEmpty(notDeletedTestCases)) {
+    if (!isEmpty(testCasesLockedByOtherUser)) {
       log.info(
           "User [{}] was unable to delete following test cases with Ids [{}] from measure [{}]",
           username,
-          String.join(", ", notDeletedTestCases),
+          String.join(", ", testCasesLockedByOtherUser),
           measureId);
       return "Successfully deleted provided test cases except [ "
-          + String.join(", ", notDeletedTestCases)
+          + String.join(", ", testCasesLockedByOtherUser)
           + " ]";
     }
     log.info(
-        "User [{}] has successfully deleted following test cases with Ids [{}] from measure [{}]",
+        "User [{}] has successfully deleted following test cases with Ids [{}] from measure [{}]. Test Cases with Ids [{}] were locked by another user and could not be deleted.",
         username,
-        String.join(", ", testCaseIds),
+        testCaseIds.stream().filter(testCaseId ->
+          !testCasesLockedByOtherUser.contains(testCaseId))
+          .collect(joining(",")), String.join(", ", testCasesLockedByOtherUser),
         measureId);
     return "Successfully deleted provided test cases";
   }

--- a/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/TestCaseServiceUtil.java
@@ -608,7 +608,7 @@ public class TestCaseServiceUtil {
     return testCaseGroupPopulations;
   }
 
-  public static boolean checkIfDeletable(
+  public static void checkIfAnyCreatedBeforeVersioning(
       List<TestCase> testCases, List<String> testCaseIds, boolean isDraft) {
     if (!isDraft) {
       boolean checkIfCreatedBeforeVersioning =
@@ -622,7 +622,6 @@ public class TestCaseServiceUtil {
         throw new InvalidIdException("Test case(s) cannot be deleted, please contact the helpdesk");
       }
     }
-    return true;
   }
 
   public static String getPatientFamilyNameFromJson(String model, String json)

--- a/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerMvcTest.java
@@ -6,26 +6,20 @@ import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.services.MeasureService;
-import cms.gov.madie.measure.services.TestCaseService;
 import cms.gov.madie.measure.services.QdmTestCaseShiftDatesService;
-
+import cms.gov.madie.measure.services.TestCaseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cms.madie.models.measure.Measure;
-import gov.cms.madie.models.measure.MeasureScoring;
-import gov.cms.madie.models.measure.PopulationType;
-import gov.cms.madie.models.measure.TestCase;
-import gov.cms.madie.models.measure.TestCaseGroupPopulation;
-import gov.cms.madie.models.measure.TestCasePopulationValue;
+import gov.cms.madie.models.measure.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -51,15 +45,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 public class TestCaseControllerMvcTest {
 
-  @MockBean private TestCaseService testCaseService;
-  @MockBean private MeasureRepository repository;
+  @MockitoBean private TestCaseService testCaseService;
+  @MockitoBean private MeasureRepository repository;
   @Autowired private MockMvc mockMvc;
-  @MockBean private MeasureService measureService;
+  @MockitoBean private MeasureService measureService;
   @Captor ArgumentCaptor<TestCase> testCaseCaptor;
   @Captor ArgumentCaptor<String> measureIdCaptor;
   @Captor ArgumentCaptor<String> testCaseIdCaptor;
   @Captor ArgumentCaptor<String> usernameCaptor;
-  @MockBean private QdmTestCaseShiftDatesService qdmTestCaseShiftDatesService;
+  @MockitoBean private QdmTestCaseShiftDatesService qdmTestCaseShiftDatesService;
 
   private TestCase testCase;
   private static final String TEST_ID = "TESTID";
@@ -216,10 +210,10 @@ public class TestCaseControllerMvcTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$[0].id").value("ID1"))
         .andExpect(jsonPath("$[0].title").value("Test1"))
-        .andExpect(jsonPath("$[0].validResource").value(true))
+        .andExpect(jsonPath("$[0].validResource").value(Boolean.TRUE))
         .andExpect(jsonPath("$[1].id").value("ID2"))
         .andExpect(jsonPath("$[1].title").value("Test2"))
-        .andExpect(jsonPath("$[1].validResource").value(false));
+        .andExpect(jsonPath("$[1].validResource").value(Boolean.FALSE));
     verify(testCaseService, times(1))
         .persistTestCases(
             testCaseListCaptor.capture(),
@@ -692,7 +686,7 @@ public class TestCaseControllerMvcTest {
                     List.of(
                         TestCasePopulationValue.builder()
                             .name(PopulationType.INITIAL_POPULATION)
-                            .expected(true)
+                            .expected(Boolean.TRUE)
                             .build()))
                 .build()));
 
@@ -841,7 +835,7 @@ public class TestCaseControllerMvcTest {
   public void testDeleteTestCases() throws Exception {
     List<String> testCaseIds = List.of("testCaseId1", "testCaseId1");
     when(testCaseService.deleteTestCases(anyString(), any(), any(String.class)))
-        .thenReturn("Succesfully deleted provided test cases");
+        .thenReturn("mock text");
 
     MvcResult result =
         mockMvc
@@ -853,10 +847,10 @@ public class TestCaseControllerMvcTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
-            .andExpect(content().string("Succesfully deleted provided test cases"))
+            .andExpect(content().string("mock text"))
             .andReturn();
 
     String response = result.getResponse().getContentAsString();
-    assertTrue(response.contains("Succesfully deleted provided test cases"));
+    assertTrue(response.contains("mock text"));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseLockServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseLockServiceTest.java
@@ -160,7 +160,10 @@ public class TestCaseLockServiceTest {
 
     LockInfo lockInfo = service.unlockTestCase("testCaseId", "test.user");
 
-    assertNull(lockInfo);
+    assertNotNull(lockInfo);
+    assertFalse(lockInfo.isLocked());
+    assertNull(lockInfo.getLockedBy());
+    assertEquals("testCaseId", lockInfo.getLockedId());
   }
 
   @Test
@@ -172,7 +175,7 @@ public class TestCaseLockServiceTest {
     assertNotNull(lockInfo);
     assertFalse(lockInfo.isLocked());
     assertNull(lockInfo.getLockedBy());
-    assertNull(lockInfo.getLockedId());
+    assertEquals("testCaseId", lockInfo.getLockedId());
   }
 
   @Test
@@ -183,8 +186,8 @@ public class TestCaseLockServiceTest {
 
     assertNotNull(lockInfo);
     assertTrue(lockInfo.isLocked());
-    assertEquals(lockInfo.getLockedId(), "testCaseId");
-    assertEquals(lockInfo.getLockedBy(), "test.user");
+    assertEquals("testCaseId", lockInfo.getLockedId());
+    assertEquals("test.user", lockInfo.getLockedBy());
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
@@ -265,7 +265,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
         .thenReturn(Optional.of(existingMeasure));
 
-    doReturn(existingMeasure).when(measureRepository).save(any(Measure.class));
+    doReturn(existingMeasure).when(measureRepository).removeTestCase(anyString(), anyString());
 
     String output = testCaseService.deleteTestCases("measure-id", List.of("TC2_ID"), "test.user");
     verify(testCaseSequenceService, times(1)).resetSequence("measure-id");
@@ -1369,10 +1369,10 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
         .thenReturn(Optional.of(existingMeasure));
 
-    doReturn(existingMeasure).when(measureRepository).save(any(Measure.class));
+    doReturn(existingMeasure).when(measureRepository).removeTestCase(anyString(), anyString());
 
     String output = testCaseService.deleteTestCases("measure-id", List.of("TC2_ID"), "test.user");
-    assertThat(output, is(equalTo("Successfully deleted provided test cases")));
+    assertThat(output, is(equalTo("Successfully deleted test cases: TC2_ID")));
   }
 
   @Test
@@ -1392,10 +1392,10 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
         .thenReturn(Optional.of(existingMeasure));
 
-    doReturn(existingMeasure).when(measureRepository).save(any(Measure.class));
+    doReturn(existingMeasure).when(measureRepository).removeTestCase(anyString(), anyString());
 
     String output = testCaseService.deleteTestCases("measure-id", List.of("TC2_ID"), "test.user");
-    assertThat(output, is(equalTo("Successfully deleted provided test cases")));
+    assertThat(output, is(equalTo("Successfully deleted test cases: TC2_ID")));
   }
 
   @Test
@@ -1548,16 +1548,22 @@ public class TestCaseServiceTest implements ResourceUtil {
     measure.setTestCases(testCases);
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
         .thenReturn(Optional.of(measure));
-    doReturn(measure).when(measureRepository).save(any(Measure.class));
+    doReturn(measure).when(measureRepository).removeTestCase(anyString(), anyString());
 
     String output =
         testCaseService.deleteTestCases(
-            measure.getId(), List.of("TC1_ID", "TC2_ID", "TC3_ID", "TC4_ID"), "test.user");
-    assertThat(output, is(equalTo("Successfully deleted provided test cases")));
+            measure.getId(), testCases.stream().map(TestCase::getId).toList(), "test.user");
+    assertThat(
+        output,
+        is(
+            equalTo(
+                "Successfully deleted test cases: "
+                    + String.join(", ", testCases.stream().map(TestCase::getId).toList()))));
   }
 
   @Test
   void testDeleteTestCasesAndReturnNotFoundTestIds() {
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)).thenReturn(true);
     List<TestCase> testCases =
         List.of(
             TestCase.builder().id("TC1_ID").title("TC1").build(),
@@ -1568,13 +1574,47 @@ public class TestCaseServiceTest implements ResourceUtil {
     measure.setTestCases(testCases);
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
         .thenReturn(Optional.of(measure));
-    doReturn(measure).when(measureRepository).save(any(Measure.class));
+    doReturn(measure).when(measureRepository).removeTestCase(anyString(), anyString());
 
     String output =
         testCaseService.deleteTestCases(
             measure.getId(), List.of("TC1_ID", "TC2_ID", "TC5_ID", "TC6_ID"), "test.user");
     assertThat(
-        output, is(equalTo("Successfully deleted provided test cases except [ TC5_ID, TC6_ID ]")));
+        output,
+        is(
+            equalTo(
+                "Successfully deleted test cases: TC1_ID, TC2_ID, unable to delete TC5_ID, TC6_ID")));
+  }
+
+  @Test
+  void testDeleteTestCasesAndReturnsLockedIds() {
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)).thenReturn(true);
+    List<TestCase> testCases =
+        List.of(
+            TestCase.builder().id("TC1_ID").title("TC1").build(),
+            TestCase.builder().id("TC2_ID").title("TC2").build(),
+            TestCase.builder().id("TC3_ID").title("TC3").build(),
+            TestCase.builder().id("TC4_ID").title("TC4").build());
+
+    measure.setTestCases(testCases);
+    when(measureRepository.findByIdAndActive(anyString(), eq(true)))
+        .thenReturn(Optional.of(measure));
+    doReturn(measure).when(measureRepository).removeTestCase(anyString(), anyString());
+    doThrow(new LockNotObtainedException())
+        .when(testCaseLockService)
+        .lockTestCaseForUser(anyString(), eq("TC1_ID"), anyString());
+    doThrow(new LockNotObtainedException())
+        .when(testCaseLockService)
+        .lockTestCaseForUser(anyString(), eq("TC2_ID"), anyString());
+
+    LockNotObtainedException thrown =
+        assertThrows(
+            LockNotObtainedException.class,
+            () ->
+                testCaseService.deleteTestCases(
+                    measure.getId(), List.of("TC1_ID", "TC2_ID", "TC3_ID"), "test.user"));
+
+    assertThat(thrown.getMessage(), is("TC1_ID,TC2_ID"));
   }
 
   @Test
@@ -3477,7 +3517,7 @@ public class TestCaseServiceTest implements ResourceUtil {
   }
 
   @Test
-  void importTestCasesReturnInvalidOutcomesWhenLockingFails() throws JsonProcessingException {
+  void importTestCasesReturnInvalidOutcomesWhenLockingFails() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)).thenReturn(true);
     measure.setTestCases(List.of(testCase));
     when(measureRepository.findByIdAndActive(anyString(), eq(true)))
@@ -3562,7 +3602,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     doReturn(mockClientResponse)
         .when(fhirServicesClient)
         .shiftTestCaseDates(anyList(), anyInt(), anyString());
-    when(testCaseLockService.unlockAllTestCases(any(List.class), anyString())).thenReturn(true);
+    when(testCaseLockService.unlockAllTestCases(anyList(), anyString())).thenReturn(true);
 
     List<TestCase> shiftedTestCases =
         testCaseService.shiftQiCoreTestCaseDates(
@@ -3577,7 +3617,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     LockInfo lock = LockInfo.builder().lockedId("TESTID").lockedBy("anotherUser").build();
     when(testCaseLockService.lockAllTestCases(anyString(), any(List.class), anyString()))
         .thenReturn(List.of(lock));
-    when(testCaseLockService.unlockAllTestCases(any(List.class), anyString())).thenReturn(true);
+    when(testCaseLockService.unlockAllTestCases(anyList(), anyString())).thenReturn(true);
 
     TestCase testCase2 = TestCase.builder().id("TESTID2").build();
     assertThrows(

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -1438,20 +1438,24 @@ public class TestCaseServiceUtilTest {
 
   @Test
   void testIfDeletableIfMeasureIsDraft() {
-    assertDoesNotThrow(() -> TestCaseServiceUtil.checkIfDeletable(List.of(), List.of(), true));
+    assertDoesNotThrow(() -> TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(List.of(), List.of(), true));
   }
 
   @Test
   void testIfDeletableIfMeasureIsNotDraftAndTestCaseIsCreatedBeforeVersioning() {
     assertThrows(
         InvalidIdException.class,
-        () -> TestCaseServiceUtil.checkIfDeletable(List.of(testCase), List.of("TESTID"), false));
+        () ->
+            TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(
+                List.of(testCase), List.of("TESTID"), false));
   }
 
   @Test
   void testIfDeletableIfMeasureIsNotDraftAndTestCaseIsCreatedAfterVersioning() {
     testCase.setCreatedBeforeVersioning(false);
     assertDoesNotThrow(
-        () -> TestCaseServiceUtil.checkIfDeletable(List.of(testCase), List.of("TESTID"), false));
+        () ->
+            TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(
+                List.of(testCase), List.of("TESTID"), false));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/TestCaseServiceUtilTest.java
@@ -1438,7 +1438,8 @@ public class TestCaseServiceUtilTest {
 
   @Test
   void testIfDeletableIfMeasureIsDraft() {
-    assertDoesNotThrow(() -> TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(List.of(), List.of(), true));
+    assertDoesNotThrow(
+        () -> TestCaseServiceUtil.checkIfAnyCreatedBeforeVersioning(List.of(), List.of(), true));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8919](https://jira.cms.gov/browse/MAT-8919)
(Optional) Related Tickets:

### Summary

Obtain a lock prior to deleting a test case. If a lock cannot be obtained, skip that test case and continue with any remaining ones. Cleanup (delete lock document) locks for now deleted test cases.

### Additional Changes
- sanitize inputs to test case deletion requests.
- Swap out deprecated Spring Boot Mockito annotation for the new one.
- Organize imports.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
