### PR TITLE
MAT-8330: Block copying test cases if the new name would be too long (more than 250 char).

### DIFF
--- a/src/main/java/cms/gov/madie/measure/dto/CopyTestCaseResult.java
+++ b/src/main/java/cms/gov/madie/measure/dto/CopyTestCaseResult.java
@@ -14,5 +14,6 @@ import java.util.List;
 @NoArgsConstructor
 public class CopyTestCaseResult {
   private List<TestCase> copiedTestCases;
+  private List<TestCase> failedTestCases;
   private Boolean didClearExpectedValues;
 }

--- a/src/main/java/cms/gov/madie/measure/exceptions/TestCaseNameLengthException.java
+++ b/src/main/java/cms/gov/madie/measure/exceptions/TestCaseNameLengthException.java
@@ -9,4 +9,8 @@ public class TestCaseNameLengthException extends RuntimeException {
   public TestCaseNameLengthException() {
     super(String.format(MESSAGE));
   }
+
+  public TestCaseNameLengthException(String testCaseId) {
+    super(String.format("%s TestCaseId: %s", MESSAGE, testCaseId));
+  }
 }

--- a/src/main/java/cms/gov/madie/measure/resources/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ErrorHandlingControllerAdvice.java
@@ -222,6 +222,13 @@ public class ErrorHandlingControllerAdvice {
     return getErrorAttributes(request, HttpStatus.BAD_REQUEST);
   }
 
+  @ExceptionHandler(TestCaseNameLengthException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseBody
+  Map<String, Object> onTestCaseNameTooLongException(WebRequest request) {
+    return getErrorAttributes(request, HttpStatus.BAD_REQUEST);
+  }
+
   private Map<String, Object> getErrorAttributes(WebRequest request, HttpStatus httpStatus) {
     // BINDING_ERRORS and STACK_TRACE are too detailed and confusing to parse
     // Let's just add a list of simplified validation errors
@@ -231,6 +238,9 @@ public class ErrorHandlingControllerAdvice {
         this.errorAttributes.getErrorAttributes(request, errorOptions);
     errorAttributes.put("status", httpStatus.value());
     errorAttributes.put("error", httpStatus.getReasonPhrase());
+    if (errorAttributes.containsKey("testCaseId")) {
+      errorAttributes.put("testCaseId", errorAttributes.get("testCaseId"));
+    }
     return errorAttributes;
   }
 }

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -109,8 +109,8 @@ public class TestCaseService {
 
     verifyUniqueTestCaseName(testCase, measure);
 
-    if (StringUtils.deleteWhitespace(testCase.getTitle() + testCase.getSeries()).length() > 255) {
-      throw new TestCaseNameLengthException();
+    if (StringUtils.join(testCase.getTitle(), testCase.getSeries()).length() > 250) {
+      throw new TestCaseNameLengthException(testCase.getId());
     }
     defaultTestCaseJsonForQdmMeasure(testCase, measure);
     checkTestCaseSpecialCharacters(testCase);
@@ -485,6 +485,7 @@ public class TestCaseService {
         TestCaseServiceUtil.getGroupsWithValidPopulations(targetMeasure.getGroups());
 
     boolean clearedExpectedValues = false;
+    List<TestCase> failedTestCases = new ArrayList<>();
     for (TestCase sourceTestCase : sourceTestCases) {
       TestCase dupTestCase = sourceTestCase.deepCopy();
 
@@ -510,19 +511,9 @@ public class TestCaseService {
       }
       Optional<TestCase> copiedTestCase = Optional.empty();
       try {
-        copiedTestCase =
-            Optional.of(persistTestCase(dupTestCase, targetMeasureId, username, accessToken));
-      } catch (DuplicateTestCaseNameException e) {
-        dupTestCase.setTitle(dupTestCase.getTitle() + "-" + new ObjectId());
-        copiedTestCase =
-            Optional.of(persistTestCase(dupTestCase, targetMeasureId, username, accessToken));
+        copiedTestCase = copyTestCaseToMeasure(targetMeasureId, dupTestCase, username, accessToken);
       } catch (TestCaseNameLengthException e) {
-        log.error(
-            "Unable to copy Test Case {} to Measure {}. "
-                + "Resulting Test Case Name would be too long.",
-            sourceTestCase.getId(),
-            targetMeasure,
-            e);
+        failedTestCases.add(sourceTestCase);
       } catch (Exception e) {
         log.error(
             "Failed to copy Test Case {} to Measure {}",
@@ -534,8 +525,19 @@ public class TestCaseService {
     }
     return CopyTestCaseResult.builder()
         .copiedTestCases(copiedTestCases)
+        .failedTestCases(failedTestCases)
         .didClearExpectedValues(Boolean.valueOf(clearedExpectedValues))
         .build();
+  }
+
+  private Optional<TestCase> copyTestCaseToMeasure(
+      String targetMeasureId, TestCase dupTestCase, String username, String accessToken) {
+    try {
+      return Optional.of(persistTestCase(dupTestCase, targetMeasureId, username, accessToken));
+    } catch (DuplicateTestCaseNameException e) {
+      dupTestCase.setTitle(dupTestCase.getTitle() + "-" + new ObjectId());
+      return Optional.of(persistTestCase(dupTestCase, targetMeasureId, username, accessToken));
+    }
   }
 
   private void clearExpectedValues(TestCase testCase) {

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
@@ -37,6 +37,7 @@ import gov.cms.madie.models.dto.TestCaseExportMetaData;
 import gov.cms.madie.models.measure.*;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -3160,6 +3161,29 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertTrue(result.getCopiedTestCases().get(0).getTitle().contains("-"));
 
     assertThat(targetMeasure.getTestCases().size(), is(2));
+  }
+
+  @Test
+  void testCopyToAnotherMeasureNameTooLong() {
+    // Set-up
+    String longName = RandomStringUtils.insecure().next(240);
+    Measure targetMeasure =
+        measure.toBuilder()
+            .testCases(new ArrayList<>(List.of(testCase.toBuilder().title(longName).build())))
+            .build();
+    TestCase source = testCase.deepCopy().toBuilder().id(null).title(longName).build();
+    assertThat(targetMeasure.getTestCases().size(), is(1));
+
+    when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
+    when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
+
+    CopyTestCaseResult result =
+        testCaseService.copyTestCasesToMeasure(
+            targetMeasure.getId(), List.of(source), "user.name", "accessToken");
+    assertThat(result.getCopiedTestCases().size(), is(0));
+    assertThat(result.getFailedTestCases().size(), is(1));
+    assertThat(result.getFailedTestCases().get(0).getTitle(), is(longName));
+    assertThat(targetMeasure.getTestCases().size(), is(1));
   }
 
   @Test

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -6,6 +6,6 @@
 
 <suppressions>
   <suppress checks="FileLength"
-    files="ParameterHandler.java"
+    files="ParameterHandler.java,TestCaseService.java"
   />
 </suppressions>


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8330](https://jira.cms.gov/browse/MAT-8330)
(Optional) Related Tickets:

### Summary

Block copying test cases to target measure if the resulting test case name would exceed the name length limit (250 char), and return a list of the test case names that failed to copy due to new name being too long to be reported on the UI.

Can occur if the target measure has a duplicate named test case that is already too close to the name length limit. When persisting the new test cases, the dedup logic will append a new ObjectId to the new test case name, causing it to run over the limit.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
