### PR TITLE
MAT-8930: TestCase Lock guard in API - Implement lock checks for all …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       WAIT_HOSTS: madie-mongo:27017
       
   madie-mongo:
-    image: mongo:4.4
+    image: mongo:6.0
     restart: always
     container_name: 'madie-mongo'
     ports:

--- a/init-mongo.js
+++ b/init-mongo.js
@@ -20,7 +20,7 @@ db.runCommand( { rolesInfo: { role: "dbOwner", db: "playground" }, showPrivilege
 db.createUser(
   { user: "gakins",
     pwd: "E5press0",
-    roles: [{ db: "madiecqllibrary", role: "readWrite" }, { db: "madie", role: "readWrite" } ]
+    roles: [{ db: "user", role: "readWrite" }, { db: "madiecqllibrary", role: "readWrite" }, { db: "madie", role: "readWrite" } ]
   }
 );
 

--- a/src/main/java/cms/gov/madie/measure/dto/BulkTestCaseResult.java
+++ b/src/main/java/cms/gov/madie/measure/dto/BulkTestCaseResult.java
@@ -1,0 +1,25 @@
+package cms.gov.madie.measure.dto;
+
+import gov.cms.madie.models.measure.TestCase;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Response DTO for bulk test case operations. Contains successfully processed test cases and IDs of
+ * failed operations.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BulkTestCaseResult {
+  /** List of successfully added/updated test cases */
+  private List<TestCase> testCases;
+
+  /** List of test case IDs that could not be processed (e.g., due to locks) */
+  private List<String> failed;
+}

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -412,8 +412,8 @@ public class MeasureController extends AbstractMeasureController {
         groupId,
         measureId);
 
-  final Measure existingMeasure = measureService.findMeasureById(measureId);
-  checkMeasureLock(existingMeasure, principal.getName());
+    final Measure existingMeasure = measureService.findMeasureById(measureId);
+    checkMeasureLock(existingMeasure, principal.getName());
     return ResponseEntity.ok(
         groupService.deleteStratification(
             measureId, groupId, stratificationId, principal.getName()));
@@ -473,7 +473,7 @@ public class MeasureController extends AbstractMeasureController {
         cmsId,
         measureId);
     final Measure existingMeasure = measureService.findMeasureById(measureId);
-      checkMeasureLock(existingMeasure, principal.getName());
+    checkMeasureLock(existingMeasure, principal.getName());
     return ResponseEntity.status(HttpStatus.OK)
         .body(measureSetService.deleteCmsId(measureId, cmsId, harpId, principal.getName()));
   }

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -443,7 +443,7 @@ public class TestCaseController {
     return false;
   }
 
-  private void checkTestCaseLock(String testCaseId, String measureId, String username) {
+  private void checkTestCaseLock(String testCaseId, String username) {
     var lock = testCaseLockService.findByTestCaseId(testCaseId);
     if (lock != null && !lock.getLockedBy().equals(username)) {
       throw new cms.gov.madie.measure.exceptions.LockNotObtainedException(

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -134,7 +134,7 @@ public class TestCaseController {
     sanitizeTestCase(testCase);
 
     // Check lock before updating
-    checkTestCaseLock(testCaseId, measureId, principal.getName());
+    checkTestCaseLock(testCaseId, principal.getName());
 
     return ResponseEntity.ok(
         testCaseService.updateTestCase(

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -133,9 +133,6 @@ public class TestCaseController {
     }
     sanitizeTestCase(testCase);
 
-    // Check lock before updating
-    checkTestCaseLock(testCaseId, principal.getName());
-
     return ResponseEntity.ok(
         testCaseService.updateTestCase(
             testCase, measureId, principal.getName(), accessToken, TestCaseServiceUtil.SAVE));
@@ -155,11 +152,6 @@ public class TestCaseController {
         principal.getName(),
         String.join(", ", testCaseIds),
         measureId);
-
-    // Check locks for all test cases before deleting
-    for (String testCaseId : testCaseIds) {
-      checkTestCaseLock(testCaseId, principal.getName());
-    }
 
     return ResponseEntity.ok(
         testCaseService.deleteTestCases(
@@ -441,13 +433,5 @@ public class TestCaseController {
       return StringUtils.containsIgnoreCase(m2.getModel(), "QI-Core");
     }
     return false;
-  }
-
-  private void checkTestCaseLock(String testCaseId, String username) {
-    var lock = testCaseLockService.findByTestCaseId(testCaseId);
-    if (lock != null && !lock.getLockedBy().equals(username)) {
-      throw new cms.gov.madie.measure.exceptions.LockNotObtainedException(
-          "Test Case [" + testCaseId + "] is locked by another user: " + lock.getLockedBy());
-    }
   }
 }

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -158,7 +158,7 @@ public class TestCaseController {
 
     // Check locks for all test cases before deleting
     for (String testCaseId : testCaseIds) {
-      checkTestCaseLock(testCaseId, measureId, principal.getName());
+      checkTestCaseLock(testCaseId, principal.getName());
     }
 
     return ResponseEntity.ok(

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseController.java
@@ -1,13 +1,16 @@
 package cms.gov.madie.measure.resources;
 
+import cms.gov.madie.measure.dto.BulkTestCaseResult;
 import cms.gov.madie.measure.dto.CopyTestCaseResult;
 import cms.gov.madie.measure.dto.ValidList;
 import cms.gov.madie.measure.exceptions.InvalidRequestException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.services.AppConfigService;
 import cms.gov.madie.measure.services.MeasureService;
 import cms.gov.madie.measure.services.QdmTestCaseShiftDatesService;
 import cms.gov.madie.measure.services.TestCaseLockEnrichmentService;
+import cms.gov.madie.measure.services.TestCaseLockService;
 import cms.gov.madie.measure.utils.TestCaseServiceUtil;
 import gov.cms.madie.models.common.ModelType;
 import cms.gov.madie.measure.services.TestCaseService;
@@ -38,6 +41,8 @@ public class TestCaseController {
   private final MeasureService measureService;
   private final QdmTestCaseShiftDatesService qdmTestCaseShiftDatesService;
   private final TestCaseLockEnrichmentService testCaseLockEnrichmentService;
+  private final AppConfigService appConfigService;
+  private final TestCaseLockService testCaseLockService;
 
   @PostMapping(ControllerUtil.TEST_CASES)
   public ResponseEntity<TestCase> addTestCase(
@@ -54,7 +59,7 @@ public class TestCaseController {
   }
 
   @PostMapping(ControllerUtil.TEST_CASES + "/list")
-  public ResponseEntity<List<TestCase>> addTestCases(
+  public ResponseEntity<BulkTestCaseResult> addTestCases(
       @RequestBody @Validated(TestCase.ValidationSequence.class) ValidList<TestCase> testCases,
       @PathVariable String measureId,
       @RequestHeader("Authorization") String accessToken,
@@ -66,10 +71,30 @@ public class TestCaseController {
     }
     Measure measure = measureOptional.get();
     measureService.verifyAuthorization(username, measure);
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(
-            testCaseService.persistTestCases(
-                testCases, measureId, principal.getName(), accessToken));
+
+    // Filter out locked test cases
+    List<TestCase> unlocked = new ArrayList<>();
+    List<String> failed = new ArrayList<>();
+
+    for (TestCase tc : testCases) {
+      if (tc.getId() != null) {
+        var lock = testCaseLockService.findByTestCaseId(tc.getId());
+        if (lock != null && !lock.getLockedBy().equals(username)) {
+          failed.add(tc.getId());
+          continue;
+        }
+      }
+      unlocked.add(tc);
+    }
+
+    List<TestCase> saved =
+        testCaseService.persistTestCases(
+            ValidList.<TestCase>builder().list(unlocked).build(), measureId, username, accessToken);
+
+    BulkTestCaseResult result =
+        BulkTestCaseResult.builder().testCases(saved).failed(failed).build();
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(result);
   }
 
   @GetMapping(ControllerUtil.TEST_CASES)
@@ -108,6 +133,9 @@ public class TestCaseController {
     }
     sanitizeTestCase(testCase);
 
+    // Check lock before updating
+    checkTestCaseLock(testCaseId, measureId, principal.getName());
+
     return ResponseEntity.ok(
         testCaseService.updateTestCase(
             testCase, measureId, principal.getName(), accessToken, TestCaseServiceUtil.SAVE));
@@ -128,22 +156,49 @@ public class TestCaseController {
         String.join(", ", testCaseIds),
         measureId);
 
+    // Check locks for all test cases before deleting
+    for (String testCaseId : testCaseIds) {
+      checkTestCaseLock(testCaseId, measureId, principal.getName());
+    }
+
     return ResponseEntity.ok(
         testCaseService.deleteTestCases(
             sanitizeUserInput(measureId), sanitizeUserInput(testCaseIds), principal.getName()));
   }
 
   @PutMapping(ControllerUtil.TEST_CASES + "/imports")
-  public ResponseEntity<List<TestCaseImportOutcome>> importTestCases(
+  public ResponseEntity<Map<String, Object>> importTestCases(
       @RequestBody List<TestCaseImportRequest> testCaseImportRequests,
       @PathVariable String measureId,
       @RequestHeader("Authorization") String accessToken,
       Principal principal) {
     final String userName = principal.getName();
+
+    // Filter out locked test cases
+    List<TestCaseImportRequest> unlocked = new ArrayList<>();
+    List<String> failed = new ArrayList<>();
+
+    for (TestCaseImportRequest request : testCaseImportRequests) {
+      String patientId = request.getPatientId() != null ? request.getPatientId().toString() : null;
+      if (patientId != null) {
+        var lock = testCaseLockService.findByTestCaseId(patientId);
+        if (lock != null && !lock.getLockedBy().equals(userName)) {
+          failed.add(patientId);
+          continue;
+        }
+      }
+      unlocked.add(request);
+    }
+
     var testCaseImportOutcomes =
         testCaseService.importTestCases(
-            testCaseImportRequests, measureId, userName, accessToken, ModelType.QI_CORE.getValue());
-    return ResponseEntity.ok().body(testCaseImportOutcomes);
+            unlocked, measureId, userName, accessToken, ModelType.QI_CORE.getValue());
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("outcomes", testCaseImportOutcomes);
+    response.put("failed", failed);
+
+    return ResponseEntity.ok().body(response);
   }
 
   private TestCase sanitizeTestCase(TestCase testCase) {
@@ -154,15 +209,37 @@ public class TestCaseController {
   }
 
   @PutMapping(ControllerUtil.TEST_CASES + "/qdm/shift-dates")
-  public ResponseEntity<List<String>> shiftQdmTestCaseDates(
+  public ResponseEntity<Map<String, Object>> shiftQdmTestCaseDates(
       @PathVariable String measureId,
       @RequestBody List<String> testCaseIds,
       @RequestParam(name = "shifted", defaultValue = "0") int shifted,
       @RequestHeader("Authorization") String accessToken,
       Principal principal) {
-    return ResponseEntity.ok(
+
+    final String username = principal.getName();
+
+    // Filter out locked test cases
+    List<String> unlocked = new ArrayList<>();
+    List<String> failed = new ArrayList<>();
+
+    for (String testCaseId : testCaseIds) {
+      var lock = testCaseLockService.findByTestCaseId(testCaseId);
+      if (lock != null && !lock.getLockedBy().equals(username)) {
+        failed.add(testCaseId);
+        continue;
+      }
+      unlocked.add(testCaseId);
+    }
+
+    List<String> shiftedIds =
         qdmTestCaseShiftDatesService.shiftTestCaseDates(
-            measureId, testCaseIds, shifted, accessToken, principal));
+            measureId, unlocked, shifted, accessToken, principal);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("shifted", shiftedIds);
+    response.put("failed", failed);
+
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping(ControllerUtil.TEST_CASES + "/qdm/shift-all-dates")
@@ -177,7 +254,7 @@ public class TestCaseController {
   }
 
   @PutMapping(ControllerUtil.TEST_CASES + "/qicore/shift-dates")
-  public ResponseEntity<List<String>> shiftQiCoreTestCaseDates(
+  public ResponseEntity<Map<String, Object>> shiftQiCoreTestCaseDates(
       @PathVariable String measureId,
       @RequestBody List<String> testCaseIds,
       @RequestParam(name = "shifted", defaultValue = "0") int shifted,
@@ -189,25 +266,38 @@ public class TestCaseController {
       throw new ResourceNotFoundException("QICore Measure", measureId);
     }
 
+    final String username = principal.getName();
+    List<String> lockedIds = new ArrayList<>();
+
+    // Filter out locked test cases
+    List<String> unlockedIds =
+        testCaseIds.stream()
+            .filter(
+                id -> {
+                  var lock = testCaseLockService.findByTestCaseId(id);
+                  boolean isLocked = lock != null && !lock.getLockedBy().equals(username);
+                  if (isLocked) {
+                    lockedIds.add(id);
+                  }
+                  return !isLocked;
+                })
+            .toList();
+
     List<TestCase> testCases =
         measure.getTestCases().stream()
-            .filter(testCase -> testCaseIds.contains(testCase.getId()))
+            .filter(testCase -> unlockedIds.contains(testCase.getId()))
             .toList();
 
     List<TestCase> shiftedTestCases =
         testCaseService.shiftQiCoreTestCaseDates(
-            testCases, shifted, accessToken, measureId, principal.getName());
+            testCases, shifted, accessToken, measureId, username);
     List<String> savedTestCaseIds = new ArrayList<>();
 
     for (TestCase shiftedTestCase : shiftedTestCases) {
       try {
         TestCase updatedTestCase =
             testCaseService.updateTestCase(
-                shiftedTestCase,
-                measureId,
-                principal.getName(),
-                accessToken,
-                TestCaseServiceUtil.SAVE);
+                shiftedTestCase, measureId, username, accessToken, TestCaseServiceUtil.SAVE);
         savedTestCaseIds.add(updatedTestCase.getId());
       } catch (Exception e) {
         log.error(
@@ -216,16 +306,20 @@ public class TestCaseController {
             e);
       }
     }
+
     List<String> failedTestCases =
-        testCases.stream()
-            .filter(testCase -> !savedTestCaseIds.contains(testCase.getId()))
-            .map(
-                testCase ->
-                    StringUtils.isBlank(testCase.getSeries())
-                        ? testCase.getTitle()
-                        : testCase.getSeries() + " - " + testCase.getTitle())
-            .toList();
-    return ResponseEntity.ok(failedTestCases);
+        new ArrayList<>(
+            testCases.stream()
+                .filter(testCase -> !savedTestCaseIds.contains(testCase.getId()))
+                .map(TestCase::getId)
+                .toList());
+    failedTestCases.addAll(lockedIds);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("shifted", savedTestCaseIds);
+    response.put("failed", failedTestCases);
+
+    return ResponseEntity.ok(response);
   }
 
   /**
@@ -240,7 +334,7 @@ public class TestCaseController {
    * @return List of Test Case names that could not be processed.
    */
   @PutMapping(ControllerUtil.TEST_CASES + "/qicore/shift-all-dates")
-  public ResponseEntity<List<String>> shiftAllQiCoreTestCaseDates(
+  public ResponseEntity<Map<String, Object>> shiftAllQiCoreTestCaseDates(
       @PathVariable String measureId,
       @RequestParam(name = "shifted", defaultValue = "0") int shifted,
       Principal principal,
@@ -250,21 +344,35 @@ public class TestCaseController {
     if (measure instanceof QdmMeasure) {
       throw new ResourceNotFoundException("QICore Measure", measureId);
     }
-    List<TestCase> testCases =
-        testCaseService.findTestCasesByMeasureId(measureId, principal.getName());
+
+    final String username = principal.getName();
+    List<TestCase> allTestCases = testCaseService.findTestCasesByMeasureId(measureId, username);
+
+    // Filter out locked test cases
+    List<String> lockedIds = new ArrayList<>();
+    List<TestCase> unlockedTestCases =
+        allTestCases.stream()
+            .filter(
+                tc -> {
+                  var lock = testCaseLockService.findByTestCaseId(tc.getId());
+                  boolean isLocked = lock != null && !lock.getLockedBy().equals(username);
+                  if (isLocked) {
+                    lockedIds.add(tc.getId());
+                  }
+                  return !isLocked;
+                })
+            .toList();
+
     List<TestCase> shiftedTestCases =
         testCaseService.shiftQiCoreTestCaseDates(
-            testCases, shifted, accessToken, measureId, principal.getName());
+            unlockedTestCases, shifted, accessToken, measureId, username);
     List<String> savedTestCaseIds = new ArrayList<>();
+
     for (TestCase shiftedTestCase : shiftedTestCases) {
       try {
         TestCase updatedTestCase =
             testCaseService.updateTestCase(
-                shiftedTestCase,
-                measureId,
-                principal.getName(),
-                accessToken,
-                TestCaseServiceUtil.SAVE);
+                shiftedTestCase, measureId, username, accessToken, TestCaseServiceUtil.SAVE);
         savedTestCaseIds.add(updatedTestCase.getId());
       } catch (Exception e) {
         log.error(
@@ -273,16 +381,20 @@ public class TestCaseController {
             e);
       }
     }
+
     List<String> failedTestCases =
-        testCases.stream()
-            .filter(testCase -> !savedTestCaseIds.contains(testCase.getId()))
-            .map(
-                testCase ->
-                    StringUtils.isBlank(testCase.getSeries())
-                        ? testCase.getTitle()
-                        : testCase.getSeries() + " - " + testCase.getTitle())
-            .toList();
-    return ResponseEntity.ok(failedTestCases);
+        new ArrayList<>(
+            unlockedTestCases.stream()
+                .filter(testCase -> !savedTestCaseIds.contains(testCase.getId()))
+                .map(TestCase::getId)
+                .toList());
+    failedTestCases.addAll(lockedIds);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("shifted", savedTestCaseIds);
+    response.put("failed", failedTestCases);
+
+    return ResponseEntity.ok(response);
   }
 
   @PutMapping(ControllerUtil.TEST_CASES + "/copy-to")
@@ -329,5 +441,13 @@ public class TestCaseController {
       return StringUtils.containsIgnoreCase(m2.getModel(), "QI-Core");
     }
     return false;
+  }
+
+  private void checkTestCaseLock(String testCaseId, String measureId, String username) {
+    var lock = testCaseLockService.findByTestCaseId(testCaseId);
+    if (lock != null && !lock.getLockedBy().equals(username)) {
+      throw new cms.gov.madie.measure.exceptions.LockNotObtainedException(
+          "Test Case [" + testCaseId + "] is locked by another user: " + lock.getLockedBy());
+    }
   }
 }

--- a/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerMvcTest.java
@@ -5,9 +5,7 @@ import cms.gov.madie.measure.exceptions.DuplicateTestCaseNameException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
-import cms.gov.madie.measure.services.MeasureService;
-import cms.gov.madie.measure.services.QdmTestCaseShiftDatesService;
-import cms.gov.madie.measure.services.TestCaseService;
+import cms.gov.madie.measure.services.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.madie.models.measure.*;
@@ -46,6 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TestCaseControllerMvcTest {
 
   @MockitoBean private TestCaseService testCaseService;
+  @MockitoBean private AppConfigService appConfigService;
+  @MockitoBean private TestCaseLockService testCaseLockService;
   @MockitoBean private MeasureRepository repository;
   @Autowired private MockMvc mockMvc;
   @MockitoBean private MeasureService measureService;
@@ -213,12 +213,14 @@ public class TestCaseControllerMvcTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$[0].id").value("ID1"))
-        .andExpect(jsonPath("$[0].title").value("Test1"))
-        .andExpect(jsonPath("$[0].validResource").value(Boolean.TRUE))
-        .andExpect(jsonPath("$[1].id").value("ID2"))
-        .andExpect(jsonPath("$[1].title").value("Test2"))
-        .andExpect(jsonPath("$[1].validResource").value(Boolean.FALSE));
+        .andExpect(jsonPath("$.testCases[0].id").value("ID1"))
+        .andExpect(jsonPath("$.testCases[0].title").value("Test1"))
+        .andExpect(jsonPath("$.testCases[0].validResource").value(Boolean.TRUE))
+        .andExpect(jsonPath("$.testCases[1].id").value("ID2"))
+        .andExpect(jsonPath("$.testCases[1].title").value("Test2"))
+        .andExpect(jsonPath("$.testCases[1].validResource").value(Boolean.FALSE))
+        .andExpect(jsonPath("$.failed").isArray())
+        .andExpect(jsonPath("$.failed").isEmpty());
     verify(testCaseService, times(1))
         .persistTestCases(
             testCaseListCaptor.capture(),

--- a/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/TestCaseControllerTest.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.resources;
 
+import cms.gov.madie.measure.dto.BulkTestCaseResult;
 import cms.gov.madie.measure.dto.ValidList;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.exceptions.UnauthorizedException;
@@ -9,7 +10,6 @@ import gov.cms.madie.models.measure.*;
 import gov.cms.madie.models.common.Version;
 import cms.gov.madie.measure.services.TestCaseService;
 import cms.gov.madie.measure.services.QdmTestCaseShiftDatesService;
-import org.apache.commons.collections4.CollectionUtils;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +41,7 @@ public class TestCaseControllerTest {
   @Mock private MeasureRepository repository;
   @Mock private MeasureService measureService;
   @Mock private QdmTestCaseShiftDatesService qdmTestCaseShiftDatesService;
+  @Mock private cms.gov.madie.measure.services.TestCaseLockService testCaseLockService;
 
   @Mock
   private cms.gov.madie.measure.services.TestCaseLockEnrichmentService
@@ -69,6 +70,9 @@ public class TestCaseControllerTest {
     measure.setMeasureName("MSR01");
     measure.setVersion(new Version(0, 0, 1));
     measure.setCreatedBy("test.user");
+
+    // Default mock behavior: no locks exist (lenient to avoid unnecessary stubbing warnings)
+    lenient().when(testCaseLockService.findByTestCaseId(anyString())).thenReturn(null);
   }
 
   @Test
@@ -128,11 +132,12 @@ public class TestCaseControllerTest {
                         .build()))
             .build();
 
-    ResponseEntity<List<TestCase>> output =
+    ResponseEntity<BulkTestCaseResult> output =
         controller.addTestCases(testCases, "MeasureID", "Bearer Token", principal);
     assertThat(output, is(notNullValue()));
     assertThat(output.getStatusCode(), is(equalTo(HttpStatus.CREATED)));
-    assertThat(output.getBody(), is(equalTo(savedTestCases)));
+    assertThat(output.getBody().getTestCases(), is(equalTo(savedTestCases)));
+    assertThat(output.getBody().getFailed().isEmpty(), is(true));
   }
 
   @Test
@@ -342,9 +347,17 @@ public class TestCaseControllerTest {
     var responseEntity =
         controller.importTestCases(
             List.of(testCaseImportRequest), measure.getId(), "TOKEN", principal);
-    assertEquals(1, Objects.requireNonNull(responseEntity.getBody()).size());
-    assertEquals(
-        testPatientId, Objects.requireNonNull(responseEntity.getBody()).get(0).getPatientId());
+
+    assertNotNull(responseEntity.getBody());
+    @SuppressWarnings("unchecked")
+    List<TestCaseImportOutcome> outcomes =
+        (List<TestCaseImportOutcome>) responseEntity.getBody().get("outcomes");
+    assertEquals(1, outcomes.size());
+    assertEquals(testPatientId, outcomes.get(0).getPatientId());
+
+    @SuppressWarnings("unchecked")
+    List<String> failed = (List<String>) responseEntity.getBody().get("failed");
+    assertTrue(failed.isEmpty());
   }
 
   @Test
@@ -374,17 +387,24 @@ public class TestCaseControllerTest {
   @Test
   void shiftQdmTestCaseDates() {
     Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn("test.user");
 
     doReturn(List.of(testCase.getId()))
         .when(qdmTestCaseShiftDatesService)
         .shiftTestCaseDates(
             any(String.class), anyList(), any(Integer.class), any(String.class), any());
-    ResponseEntity<List<String>> response =
+    ResponseEntity<Map<String, Object>> response =
         controller.shiftQdmTestCaseDates(
             measure.getId(), List.of(testCase.getId()), 1, "TOKEN", principal);
 
     assertNotNull(response.getBody());
-    assertEquals(testCase.getId(), response.getBody().get(0));
+    @SuppressWarnings("unchecked")
+    List<String> shiftedIds = (List<String>) response.getBody().get("shifted");
+    assertEquals(testCase.getId(), shiftedIds.get(0));
+
+    @SuppressWarnings("unchecked")
+    List<String> failed = (List<String>) response.getBody().get("failed");
+    assertTrue(failed.isEmpty());
   }
 
   @Test
@@ -430,7 +450,7 @@ public class TestCaseControllerTest {
         .when(testCaseService)
         .shiftQiCoreTestCaseDates(anyList(), anyInt(), anyString(), anyString(), anyString());
 
-    ResponseEntity<List<String>> response =
+    ResponseEntity<Map<String, Object>> response =
         controller.shiftQiCoreTestCaseDates(
             fhirMeasure.getId(),
             List.of(fhirMeasure.getTestCases().get(0).getId()),
@@ -438,7 +458,14 @@ public class TestCaseControllerTest {
             "TOKEN",
             principal);
     assertThat(response.getStatusCode(), equalTo(HttpStatusCode.valueOf(200)));
-    assertTrue(CollectionUtils.isEmpty(response.getBody()));
+
+    @SuppressWarnings("unchecked")
+    List<String> shiftedIds = (List<String>) response.getBody().get("shifted");
+    assertEquals(1, shiftedIds.size());
+
+    @SuppressWarnings("unchecked")
+    List<String> failedIds = (List<String>) response.getBody().get("failed");
+    assertTrue(failedIds.isEmpty());
   }
 
   @Test
@@ -467,14 +494,16 @@ public class TestCaseControllerTest {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn("test.user");
 
-    doReturn(testCase)
+    // When updateTestCase is called, return testCase2
+    doReturn(testCase2)
         .when(testCaseService)
         .updateTestCase(any(), anyString(), anyString(), anyString(), anyString());
+    // Only testCase2 was successfully shifted, testCase was not
     doReturn(List.of(testCase2))
         .when(testCaseService)
         .shiftQiCoreTestCaseDates(anyList(), anyInt(), anyString(), anyString(), anyString());
 
-    ResponseEntity<List<String>> response =
+    ResponseEntity<Map<String, Object>> response =
         controller.shiftQiCoreTestCaseDates(
             fhirMeasure.getId(),
             List.of(
@@ -484,8 +513,15 @@ public class TestCaseControllerTest {
             "TOKEN",
             principal);
     assertThat(response.getStatusCode(), equalTo(HttpStatusCode.valueOf(200)));
-    assertThat(response.getBody().size(), equalTo(1));
-    assertThat(response.getBody().get(0), equalTo("title"));
+
+    @SuppressWarnings("unchecked")
+    List<String> shiftedIds = (List<String>) response.getBody().get("shifted");
+    assertEquals(1, shiftedIds.size());
+
+    @SuppressWarnings("unchecked")
+    List<String> failedIds = (List<String>) response.getBody().get("failed");
+    assertEquals(1, failedIds.size());
+    assertEquals(testCase.getId(), failedIds.get(0));
   }
 
   @Test
@@ -535,10 +571,17 @@ public class TestCaseControllerTest {
         .when(testCaseService)
         .shiftQiCoreTestCaseDates(anyList(), anyInt(), anyString(), anyString(), anyString());
 
-    ResponseEntity<List<String>> response =
+    ResponseEntity<Map<String, Object>> response =
         controller.shiftAllQiCoreTestCaseDates(fhirMeasure.getId(), 1, principal, "TOKEN");
     assertThat(response.getStatusCode(), equalTo(HttpStatusCode.valueOf(200)));
-    assertTrue(CollectionUtils.isEmpty(response.getBody()));
+
+    @SuppressWarnings("unchecked")
+    List<String> shiftedIds = (List<String>) response.getBody().get("shifted");
+    assertEquals(1, shiftedIds.size());
+
+    @SuppressWarnings("unchecked")
+    List<String> failedIds = (List<String>) response.getBody().get("failed");
+    assertTrue(failedIds.isEmpty());
   }
 
   @Test
@@ -570,12 +613,18 @@ public class TestCaseControllerTest {
         .when(testCaseService)
         .shiftQiCoreTestCaseDates(anyList(), anyInt(), anyString(), anyString(), anyString());
 
-    ResponseEntity<List<String>> response =
+    ResponseEntity<Map<String, Object>> response =
         controller.shiftAllQiCoreTestCaseDates(fhirMeasure.getId(), 1, principal, "TOKEN");
     assertThat(response.getStatusCode(), equalTo(HttpStatusCode.valueOf(200)));
-    assertTrue(CollectionUtils.isNotEmpty(response.getBody()));
-    assertThat(response.getBody().size(), equalTo(1));
-    assertThat(response.getBody().get(0), equalTo("testCase - bad"));
+
+    @SuppressWarnings("unchecked")
+    List<String> shiftedIds = (List<String>) response.getBody().get("shifted");
+    assertEquals(1, shiftedIds.size());
+
+    @SuppressWarnings("unchecked")
+    List<String> failedIds = (List<String>) response.getBody().get("failed");
+    assertEquals(1, failedIds.size());
+    assertEquals("7890", failedIds.get(0));
   }
 
   @Test


### PR DESCRIPTION
…TestCase modification endpoints

- Add checkTestCaseLock helper method to prevent updates to locked test cases
- Single operations (PUT/DELETE) throw LockNotObtainedException (HTTP 423) if locked
- Bulk operations (POST/PUT) skip locked test cases and return failed IDs
- Implemented lock checks in 7 endpoints:
  * PUT /test-cases/{id} - single update
  * DELETE /test-cases - delete multiple
  * POST /test-cases/list - bulk add
  * PUT /test-cases/imports - import
  * PUT /test-cases/qdm/shift-dates - QDM date shift
  * PUT /test-cases/qicore/shift-dates - QI-Core date shift
  * PUT /test-cases/qicore/shift-all-dates - QI-Core shift all
- Add BulkTestCaseResult DTO for bulk operations response
- Update tests to verify lock guard behavior

## MADiE PR

Jira Ticket: [MAT-8930](https://jira.cms.gov/browse/MAT-8930)
(Optional) Related Tickets:

### Summary

### All Submissions
* [X] This PR has the JIRA linked.
* [X] Required tests are included.
* [X] No extemporaneous files are included (i.e Complied files or testing results).
* [X] This PR is merging into the **correct branch**.
* [X] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
