### PR TITLE
MAT-9095: Check for feature flag prior to enriching measure query results with owner details.

### DIFF
--- a/src/main/java/cms/gov/madie/measure/dto/MadieFeatureFlag.java
+++ b/src/main/java/cms/gov/madie/measure/dto/MadieFeatureFlag.java
@@ -9,7 +9,8 @@ public enum MadieFeatureFlag {
   EDIT_TESTS_ON_VERSIONED_MEASURES("EditTestsOnVersionedMeasures"),
   STU_6_TEST_CASE_VALIDATION("stu6TestCaseValidation"),
   LOCKING("Locking"),
-  QICORE_ELEMENTS_TAB("qiCoreElementsTab");
+  QICORE_ELEMENTS_TAB("qiCoreElementsTab"),
+  DISPLAY_OWNER("DisplayOwner");
 
   private final String flag;
 

--- a/src/main/java/cms/gov/madie/measure/repositories/MeasureSearchServiceImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/MeasureSearchServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static cms.gov.madie.measure.dto.MadieFeatureFlag.DISPLAY_OWNER;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 
 @Repository
@@ -301,6 +302,9 @@ public class MeasureSearchServiceImpl implements MeasureSearchService {
    * @param measureListDTOs List of MeasureListDTO objects to populate
    */
   private void populateOwnerDisplayNames(List<MeasureListDTO> measureListDTOs) {
+    if (!appConfigService.isFlagEnabled(DISPLAY_OWNER)) {
+      return;
+    }
     if (CollectionUtils.isEmpty(measureListDTOs)) {
       return;
     }

--- a/src/test/java/cms/gov/madie/measure/repositories/MeasureSearchServiceImplTest.java
+++ b/src/test/java/cms/gov/madie/measure/repositories/MeasureSearchServiceImplTest.java
@@ -547,6 +547,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testSearchMeasuresPopulatesOwnerDisplayNames() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet1 = MeasureSet.builder().owner("harpId1").build();
@@ -600,6 +601,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testPopulateOwnerDisplayNamesWithFirstNameOnly() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet = MeasureSet.builder().owner("harpId1").build();
@@ -635,6 +637,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testPopulateOwnerDisplayNamesWithLastNameOnly() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet = MeasureSet.builder().owner("harpId1").build();
@@ -670,6 +673,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testPopulateOwnerDisplayNamesWithEmptyNames() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet = MeasureSet.builder().owner("harpId1").build();
@@ -705,6 +709,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testPopulateOwnerDisplayNamesWithUserNotFound() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet = MeasureSet.builder().owner("harpId1").build();
@@ -817,6 +822,7 @@ public class MeasureSearchServiceImplTest {
   @Test
   public void testPopulateOwnerDisplayNamesDeduplicatesOwners() {
     when(appConfigService.isFlagEnabled(MadieFeatureFlag.MEASURE_SEARCH)).thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.DISPLAY_OWNER)).thenReturn(true);
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     MeasureSet measureSet1 = MeasureSet.builder().owner("harpId1").build();


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9095](https://jira.cms.gov/browse/MAT-9095)
(Optional) Related Tickets:

### Summary

`populateOwnerDisplayNames` enriches the measure list result with measure owner details retrieved from user-service. When the `displayOwner` flag is disabled, the owner details will not be displayed. Skip this enrichment whenever the flag is disabled.



Also, there's a env config issue causing errors every time measure-service calls user-service, this change will also reduce the number of non-useful calls to user-service to limit excessive errors.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
