### PR TITLE
MAT-9501: When updating measures, only consider TC locks during group modifications; Deprecate unused Endpoints

### DIFF
--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -378,6 +378,7 @@ public class MeasureController extends AbstractMeasureController {
     return ResponseEntity.ok(measure);
   }
 
+  @Deprecated
   @PostMapping("/measures/{measureId}/groups/{groupId}/stratification")
   public ResponseEntity<Stratification> createStratification(
       @RequestBody Stratification stratification,
@@ -390,6 +391,7 @@ public class MeasureController extends AbstractMeasureController {
                 groupId, measureId, stratification, principal.getName()));
   }
 
+  @Deprecated
   @PutMapping("/measures/{measureId}/groups/{groupId}/stratification")
   public ResponseEntity<Stratification> updateStratification(
       @RequestBody Stratification stratification,
@@ -403,6 +405,7 @@ public class MeasureController extends AbstractMeasureController {
         groupService.createOrUpdateStratification(groupId, measureId, stratification, username));
   }
 
+  @Deprecated
   @DeleteMapping("/measures/{measureId}/groups/{groupId}/stratification/{stratificationId}")
   public ResponseEntity<Measure> deleteStratification(
       @RequestBody @PathVariable String measureId,

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -5,6 +5,7 @@ import cms.gov.madie.measure.exceptions.*;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.repositories.MeasureSetRepository;
 import cms.gov.madie.measure.services.*;
+import cms.gov.madie.measure.utils.MeasureUtil;
 import gov.cms.madie.models.access.AclOperation;
 import gov.cms.madie.models.access.AclSpecification;
 import gov.cms.madie.models.common.Action;
@@ -16,6 +17,7 @@ import gov.cms.madie.models.measure.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -26,7 +28,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -198,10 +199,12 @@ public class MeasureController extends AbstractMeasureController {
           measureService.verifyAuthorization(username, measure, null);
         }
 
+        // Group changes are not allowed if any test case is locked by another user
         if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)
-            && testCaseLockService.isAnyTestCaseLockedByOthers(existingMeasure.getId(), username)) {
+            && testCaseLockService.isAnyTestCaseLockedByOthers(existingMeasure.getId(), username)
+            && MeasureUtil.isMeasureGroupsChanged(measure, existingMeasure)) {
           throw new LockNotObtainedException(
-              "Unable to update measure.  One or more test cases are locked by another user.");
+              "Unable to update measure groups. One or more test cases are locked by another user.");
         }
 
         // clear testcase groups for qdm when scoring or patient basis is changed.
@@ -552,7 +555,6 @@ public class MeasureController extends AbstractMeasureController {
    * @param oldMeasureId ID of the old measure to compare from
    * @param newMeasureId ID of the new measure to compare to
    * @param autoReorder Whether to auto-reorder the new measure CQL (default: true)
-   * @param principal Current user principal
    * @return CqlDiffResult containing normalized/reordered text ready for diff display
    */
   @GetMapping(value = "/measures/{oldMeasureId}/compare/{newMeasureId}")

--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -67,7 +67,7 @@ public class GroupService {
     if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)
         && testCaseLockService.isAnyTestCaseLockedByOthers(measureId, username)) {
       throw new LockNotObtainedException(
-          "Unable to update measure.  One or more test cases are locked by another user.");
+          "Unable to create or update measure groups. One or more test cases are locked by another user.");
     }
 
     if (measure.getModel().equalsIgnoreCase(ModelType.QDM_5_6.getValue())) {

--- a/src/main/java/cms/gov/madie/measure/utils/MeasureUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/MeasureUtil.java
@@ -200,6 +200,16 @@ public class MeasureUtil {
             persistedMeasure.getMeasurementPeriodEnd(), measure.getMeasurementPeriodEnd());
   }
 
+  public static boolean isMeasureGroupsChanged(Measure changed, Measure original) {
+    if (CollectionUtils.isEmpty(original.getGroups())) {
+      return !CollectionUtils.isEmpty(changed.getGroups());
+    }
+    if (CollectionUtils.isEmpty(changed.getGroups())) {
+      return !CollectionUtils.isEmpty(original.getGroups());
+    }
+    return !CollectionUtils.isEqualCollection(changed.getGroups(), original.getGroups());
+  }
+
   public boolean isSupplementalDataChanged(Measure changed, Measure original) {
     if (CollectionUtils.isEmpty(original.getSupplementalData())) {
       return !CollectionUtils.isEmpty(changed.getSupplementalData());

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -33,11 +33,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -568,7 +564,7 @@ class MeasureControllerTest {
   }
 
   @Test
-  void testUpdateMeasureReturnsExceptionForLockedTestCases() {
+  void testUpdateMeasureReturnsExceptionForLockedTestCasesWhenUpdatingGroups() {
     Measure m1234 =
         measure1.toBuilder()
             .id("ID1234")
@@ -581,9 +577,54 @@ class MeasureControllerTest {
     when(testCaseLockService.isAnyTestCaseLockedByOthers(anyString(), anyString()))
         .thenReturn(true);
 
+    Measure updatedMeasure =
+        m1234.toBuilder().groups(List.of(Group.builder().id("group_1").build())).build();
+
     assertThrows(
         LockNotObtainedException.class,
-        () -> controller.updateMeasure("ID1234", m1234, principal, "Bearer TOKEN"));
+        () -> controller.updateMeasure("ID1234", updatedMeasure, principal, "Bearer TOKEN"));
+  }
+
+  @Test
+  void testTopLevelUpdateMeasureSuccessfulWhenTestCaseLocked() {
+    Measure m1234 =
+        measure1.toBuilder()
+            .id("ID1234")
+            .createdBy("test.user2")
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
+            .groups(List.of(Group.builder().id("group_1").build()))
+            .build();
+    when(principal.getName()).thenReturn("test.user2");
+    when(measureService.findMeasureById(anyString())).thenReturn(m1234);
+    when(appConfigService.isFlagEnabled(any())).thenReturn(true);
+    when(testCaseLockService.isAnyTestCaseLockedByOthers(anyString(), anyString()))
+        .thenReturn(true);
+
+    Measure updatedMeasure = m1234.toBuilder().measureName("New Name").build();
+
+    assertDoesNotThrow(
+        () -> controller.updateMeasure("ID1234", updatedMeasure, principal, "Bearer TOKEN"));
+  }
+
+  @Test
+  void testUpdateMeasureSuccessfulWhenNoTestCasesLocked() {
+    Measure m1234 =
+        measure1.toBuilder()
+            .id("ID1234")
+            .createdBy("test.user2")
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
+            .groups(List.of(Group.builder().id("group_1").build()))
+            .build();
+    when(principal.getName()).thenReturn("test.user2");
+    when(measureService.findMeasureById(anyString())).thenReturn(m1234);
+    when(appConfigService.isFlagEnabled(any())).thenReturn(true);
+    when(testCaseLockService.isAnyTestCaseLockedByOthers(anyString(), anyString()))
+        .thenReturn(false);
+
+    Measure updatedMeasure = m1234.toBuilder().measureName("New Name").build();
+
+    assertDoesNotThrow(
+        () -> controller.updateMeasure("ID1234", updatedMeasure, principal, "Bearer TOKEN"));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/utils/MeasureUtilTest.java
+++ b/src/test/java/cms/gov/madie/measure/utils/MeasureUtilTest.java
@@ -1128,4 +1128,58 @@ class MeasureUtilTest {
     List<IncludedLibrary> result = MeasureUtil.getIncludedLibraries("");
     assertThat(result.size(), is(0));
   }
+
+  @Test
+  public void testIsMeasureGroupChangedReturnsFalseForNullObjects() {
+    Measure updatingMeasure = Measure.builder().groups(null).build();
+    Measure existingMeasure = Measure.builder().groups(null).build();
+    assertFalse(MeasureUtil.isMeasureGroupsChanged(updatingMeasure, existingMeasure));
+  }
+
+  @Test
+  public void testIsMeasureGroupChangedReturnsTrueWhenNewGroupIsAdded() {
+    Group group =
+        Group.builder()
+            .id("Group1")
+            .scoring(MeasureScoring.PROPORTION.toString())
+            .populations(
+                List.of(
+                    Population.builder().definition("IPP").build(),
+                    Population.builder().definition("DENOM").build(),
+                    Population.builder().definition("NUMER").build()))
+            .build();
+    Measure newGroup = Measure.builder().groups(List.of(group)).build();
+    Measure nullGroup = Measure.builder().groups(null).build();
+    boolean existingIsNull = MeasureUtil.isMeasureGroupsChanged(newGroup, nullGroup);
+    assertTrue(existingIsNull);
+
+    boolean modifiedIsNull = MeasureUtil.isMeasureGroupsChanged(nullGroup, newGroup);
+    assertTrue(modifiedIsNull);
+  }
+
+  @Test
+  public void testIsMeasureGroupChangedReturnsTrueWhenGroupModified() {
+    Group group =
+      Group.builder()
+        .id("Group1")
+        .scoring(MeasureScoring.PROPORTION.toString())
+        .populations(
+          List.of(
+            Population.builder().definition("IPP").build(),
+            Population.builder().definition("DENOM").build(),
+            Population.builder().definition("NUMER").build()))
+        .build();
+    Group modifiedGroup =
+      Group.builder()
+        .id("Group1")
+        .scoring(MeasureScoring.COHORT.toString())
+        .populations(
+          List.of(
+            Population.builder().definition("IPP").build()))
+        .build();
+    Measure updatingMeasure = Measure.builder().groups(List.of(modifiedGroup)).build();
+    Measure existingMeasure = Measure.builder().groups(List.of(group)).build();
+    boolean result = MeasureUtil.isMeasureGroupsChanged(updatingMeasure, existingMeasure);
+    assertTrue(result);
+  }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9501](https://jira.cms.gov/browse/MAT-9501)
(Optional) Related Tickets:

### Summary

In `updateMeasure`, TC locks were being consideration for any update and now will be limited to only group modifications.


Implementation Note: `CollectionUtils.isEqualCollection` _seems_ performant for this usage based on a cursory inspection of its impl, however; it does require arguments to be non-null. To maintain decent readability with multiple null checks, I created a new MeasureUtil method using isEqualCollection to verify if any changes were made to Measure groups.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
