### PR TITLE
MAT-9511: Prevent Group Deletion if one or more Test Cases are Locked by other user(s)

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,8 +2,15 @@ coverage:
   status:
     project:
       default:   # default is the status check's name, not default settings
-        target: 90
-        threshold: 5
+        target: 90%
+        threshold: 10%
         base: auto
         paths:
           - "src"
+    patch:
+        default:
+            target: 90%
+            threshold: 10%
+            base: auto
+            paths:
+            - "src"

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -346,7 +346,11 @@ public class MeasureController extends AbstractMeasureController {
         principal.getName(),
         groupId,
         measureId);
-    Measure measure = groupService.deleteMeasureGroup(measureId, groupId, principal.getName());
+    checkMeasureLock(measureService.findMeasureById(measureId), principal.getName().toLowerCase());
+    Measure measure =
+        groupService.deleteMeasureGroup(measureId, groupId, principal.getName().toLowerCase());
+    // Setting measure.measureLock to null prevents the UI from deleting the existing measure lock.
+    // Which is its own problem.
     measure.setMeasureLock(measureService.getMeasureLock(measureId, principal.getName()));
     return ResponseEntity.ok(measure);
   }
@@ -387,8 +391,9 @@ public class MeasureController extends AbstractMeasureController {
       Principal principal) {
 
     log.info(
-        "User [{}] is attempting to delete a group with Id [{}] from measure [{}]",
+        "User [{}] is attempting to delete a stratification with Id [{}] from group with Id [{}] from measure [{}]",
         principal.getName(),
+        stratificationId,
         groupId,
         measureId);
 

--- a/src/main/java/cms/gov/madie/measure/resources/TestCaseLockController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/TestCaseLockController.java
@@ -33,6 +33,7 @@ public class TestCaseLockController {
   public ResponseEntity<Boolean> isTestCaseLockedByOtherUser(
       @PathVariable String measureId, Principal principal) {
     return ResponseEntity.ok(
-        testCaseLockService.isAnyTestCaseLockedByOthers(measureId, principal.getName()));
+        testCaseLockService.isAnyTestCaseLockedByOthers(
+            measureId, principal.getName().toLowerCase()));
   }
 }

--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -73,7 +73,7 @@ public class GroupService {
     }
 
     if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)
-        && testCaseLockService.isAnyTestCaseLockedByOthers(measureId, username)) {
+        && testCaseLockService.isAnyTestCaseLockedByOthers(measureId, username.toLowerCase())) {
       throw new LockNotObtainedException(
           "Unable to create or update measure groups. One or more test cases are locked by another user.");
     }
@@ -192,6 +192,12 @@ public class GroupService {
 
     if (groupId == null || groupId.trim().isEmpty()) {
       throw new InvalidIdException("Measure group Id cannot be null");
+    }
+
+    if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)
+        && testCaseLockService.isAnyTestCaseLockedByOthers(measureId, username.toLowerCase())) {
+      throw new LockNotObtainedException(
+          "Unable to delete measure groups. One or more test cases are locked by another user.");
     }
 
     List<Group> remainingGroups =

--- a/src/main/java/cms/gov/madie/measure/services/MeasureLockService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureLockService.java
@@ -133,6 +133,6 @@ public class MeasureLockService {
 
   public MeasureLock findByMeasureId(String measureId) {
     Optional<MeasureLock> existingLock = measureLockRepository.findByMeasureId(measureId);
-    return existingLock.isPresent() ? existingLock.get() : null;
+    return existingLock.orElse(null);
   }
 }

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -940,6 +940,8 @@ public class MeasureService extends BaseMeasureService {
     return measureHistory;
   }
 
+  // Returns Lock info if measure is locked by non-current user, else (locked by current user or no
+  // lock) returns null
   public gov.cms.madie.models.measure.MeasureLock getMeasureLock(
       String measureId, String username) {
     if (appConfigService.isFlagEnabled(MadieFeatureFlag.LOCKING)) {

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -720,21 +720,17 @@ class MeasureControllerTest {
   @Test
   void deleteGroupWithMeasureLocked() {
     when(principal.getName()).thenReturn("test.user");
+    when(appConfigService.isFlagEnabled(any())).thenReturn(true);
 
-    Measure updatedMeasure =
-        Measure.builder().id("measure-id").createdBy("test.user").groups(null).build();
-    when(measureService.getMeasureLock(anyString(), anyString()))
-        .thenReturn(MeasureLock.builder().lockedBy("anotherUser").build());
-    doReturn(updatedMeasure)
-        .when(groupService)
-        .deleteMeasureGroup(any(String.class), any(String.class), any(String.class));
-
-    ResponseEntity<Measure> output =
-        controller.deleteMeasureGroup("measure-id", "testgroupid", principal);
-
-    assertThat(output.getStatusCode(), is(equalTo(HttpStatus.OK)));
-    assertNull(output.getBody().getGroups());
-    assertEquals("anotherUser", output.getBody().getMeasureLock().getLockedBy());
+    when(measureService.findMeasureById(anyString()))
+        .thenReturn(
+            Measure.builder()
+                .id("measure-id")
+                .measureLock(MeasureLock.builder().lockedBy("another.user").build())
+                .build());
+    assertThrows(
+        LockNotObtainedException.class,
+        () -> controller.deleteMeasureGroup("measure-id", "testgroupid", principal));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
@@ -463,7 +463,9 @@ public class GroupServiceTest implements ResourceUtil {
             .groups(List.of(group))
             .measureMetaData(MeasureMetaData.builder().draft(true).build())
             .measureSet(MeasureSet.builder().owner("test.user").build())
+            .measureLock(MeasureLock.builder().lockedBy("test.user").build())
             .build();
+    when(appConfigService.isFlagEnabled(any())).thenReturn(true);
     when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
     doReturn(existingMeasure).when(measureRepository).save(any(Measure.class));
@@ -620,6 +622,23 @@ public class GroupServiceTest implements ResourceUtil {
     assertThrows(
         InvalidDraftStatusException.class,
         () -> groupService.deleteMeasureGroup("measure-id", groupId, "user2"));
+  }
+
+  @Test
+  void testDeleteGroupThrowsExceptionWhenTestCasesLockedByOtherUser() {
+    Measure existingMeasure =
+        Measure.builder()
+            .id("measure-id")
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
+            .build();
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
+    when(appConfigService.isFlagEnabled(any())).thenReturn(true);
+    when(testCaseLockService.isAnyTestCaseLockedByOthers(anyString(), anyString()))
+        .thenReturn(true);
+
+    assertThrows(
+        LockNotObtainedException.class,
+        () -> groupService.deleteMeasureGroup("measure-id", "testgroupid", "test.user"));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9511](https://jira.cms.gov/browse/MAT-9511)
(Optional) Related Tickets:

### Summary

Verify Measure and Test Case Lock conditions prior to Group deletion.

User attempting to delete a Measure Group must have Measure Lock as well as all relevant Test Case Locks. If 1 or more Test Cases are locked by another user, prevent Group deletion.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
