### PR TITLE
MAT-9869 Add TestCaseSetId On Measure Draft

### DIFF
--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepository.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepository.java
@@ -21,4 +21,6 @@ public interface TestCaseRepository {
 
   Measure findAndUpdateValidationResults(
       String testCaseId, String measureId, UUID taskId, HapiOperationOutcome validationResults);
+
+  boolean testCaseSetIdExistsInSet(String measureId);
 }

--- a/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
+++ b/src/main/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImpl.java
@@ -147,6 +147,26 @@ public class TestCaseRepositoryImpl implements TestCaseRepository {
   }
 
   /**
+   * Checks if any TestCase within a Measure (identified by its measureSetId) has a non-null
+   * testCaseSetId value.
+   *
+   * @param measureSetId The measureSetId of the Measure to search within.
+   * @return {@code true} if at least one TestCase with a non-null testCaseSetId is found, {@code
+   *     false} otherwise.
+   */
+  @Override
+  public boolean testCaseSetIdExistsInSet(String measureSetId) {
+    Query query =
+        new Query(
+            Criteria.where("measureSetId")
+                .is(measureSetId)
+                .and("testCases.testCaseSetId")
+                .exists(true)
+                .ne(null));
+    return mongoOperations.exists(query, Measure.class);
+  }
+
+  /**
    * Updates the validation results of a specific TestCase within a Measure after HAPI FHIR
    * validation completes. This only applies if the current status is VALIDATING and the taskId
    * matches.

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -265,7 +265,7 @@ public class VersionService {
     measureDraft.getMeasureMetaData().setVersionDate(null);
     measureDraft.setGroups(cloneMeasureGroups(measure.getGroups()));
     measureDraft.setReviewMetaData(new ReviewMetaData());
-    // back-fill test case set ids to versione measure test cases and carry them over to draft
+    // back-fill test case set ids to versioned measure test cases and carry them over to draft
     if (appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)
         && !ModelType.QDM_5_6.getValue().equalsIgnoreCase(measure.getModel())) {
       boolean testCaseSetIdsExistInMeasureSet =

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -276,7 +276,7 @@ public class VersionService {
             measure.getId());
 
         measure.getTestCases().forEach(testCase -> testCase.setTestCaseSetId(UUID.randomUUID()));
-        measureRepository.save(measureDraft);
+        measureRepository.save(measure);
       }
     }
 

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -1,10 +1,9 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.MadieFeatureFlag;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.*;
-import cms.gov.madie.measure.repositories.CqmMeasureRepository;
-import cms.gov.madie.measure.repositories.ExportRepository;
-import cms.gov.madie.measure.repositories.MeasureRepository;
+import cms.gov.madie.measure.repositories.*;
 import cms.gov.madie.measure.utils.RichTextUtil;
 import cms.gov.madie.measure.utils.TestCaseServiceUtil;
 import gov.cms.madie.models.common.ActionType;
@@ -16,10 +15,10 @@ import gov.cms.madie.packaging.utils.PackagingUtility;
 import gov.cms.madie.packaging.utils.PackagingUtilityFactory;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
@@ -266,6 +265,20 @@ public class VersionService {
     measureDraft.getMeasureMetaData().setVersionDate(null);
     measureDraft.setGroups(cloneMeasureGroups(measure.getGroups()));
     measureDraft.setReviewMetaData(new ReviewMetaData());
+    // back-fill test case set ids to versione measure test cases and carry them over to draft
+    if (appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)
+        && !ModelType.QDM_5_6.getValue().equalsIgnoreCase(measure.getModel())) {
+      boolean testCaseSetIdsExistInMeasureSet =
+          measureRepository.testCaseSetIdExistsInSet(measure.getMeasureSetId());
+      if (!testCaseSetIdsExistInMeasureSet && CollectionUtils.isNotEmpty(measure.getTestCases())) {
+        log.warn(
+            "Measure with id [{}] does not have test cases with set ids adding them.",
+            measure.getId());
+
+        measure.getTestCases().forEach(testCase -> testCase.setTestCaseSetId(UUID.randomUUID()));
+        measureRepository.save(measureDraft);
+      }
+    }
 
     measureDraft.setTestCases(cloneTestCases(measure, measureDraft.getGroups(), accessToken));
     var now = Instant.now();

--- a/src/test/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImplTest.java
+++ b/src/test/java/cms/gov/madie/measure/repositories/TestCaseRepositoryImplTest.java
@@ -177,6 +177,30 @@ class TestCaseRepositoryImplTest {
   }
 
   @Test
+  void testCaseSetIdExistsInSetShouldReturnTrueWhenExists() {
+    String measureSetId = "measureSet123";
+
+    when(mongoOperations.exists(any(Query.class), eq(Measure.class))).thenReturn(true);
+
+    boolean result = testCaseRepository.testCaseSetIdExistsInSet(measureSetId);
+
+    assertTrue(result);
+    verify(mongoOperations, times(1)).exists(any(Query.class), eq(Measure.class));
+  }
+
+  @Test
+  void testCaseSetIdExistsInSetShouldReturnFalseWhenNotExists() {
+    String measureSetId = "measureSet123";
+
+    when(mongoOperations.exists(any(Query.class), eq(Measure.class))).thenReturn(false);
+
+    boolean result = testCaseRepository.testCaseSetIdExistsInSet(measureSetId);
+
+    assertFalse(result);
+    verify(mongoOperations, times(1)).exists(any(Query.class), eq(Measure.class));
+  }
+
+  @Test
   void findAndUpdateValidationResultsShouldUpdateValidationResult() {
     String testCaseId = new ObjectId().toString();
     String measureId = "measure123";

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.MadieFeatureFlag;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.BadVersionRequestException;
 import cms.gov.madie.measure.exceptions.BundleOperationException;
@@ -1825,6 +1826,185 @@ public class VersionServiceTest {
     assertEquals(savedValue.getId(), capturedExport.getMeasureId());
     assertEquals("hex1", capturedExport.getMeasureBundleGridFsId());
     assertEquals("hex2", capturedExport.getMeasureBundleWithoutWarningsGridFsId());
+  }
+
+  @Test
+  public void testCreateDraftSkipsTestCaseSetIdBackfillWhenFeatureFlagDisabled() {
+    Measure versionedMeasure = buildBasicMeasure();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    Measure draftCopy =
+        versionedMeasure.toBuilder()
+            .id("2")
+            .versionId("13-13-13-13")
+            .measureName("Test")
+            .model(MODEL_QI_CORE)
+            .measureMetaData(metaData)
+            .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+            anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)).thenReturn(false);
+    when(measureRepository.save(any(Measure.class))).thenReturn(draftCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+        .thenReturn(true);
+
+    versionService.createDraft(
+        versionedMeasure.getId(), "Test", MODEL_QI_CORE, "test-user", TEST_ACCESS_TOKEN);
+
+    // testCaseSetIdExistsInSet must never be consulted when the flag is off
+    verify(measureRepository, never()).testCaseSetIdExistsInSet(anyString());
+  }
+
+  @Test
+  public void testCreateDraftSkipsTestCaseSetIdBackfillForQDMMeasure() {
+    String model = ModelType.QDM_5_6.getValue();
+    Measure versionedMeasure = buildBasicMeasure();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    versionedMeasure.setModel(model);
+    Measure draftCopy =
+      versionedMeasure.toBuilder()
+        .id("2")
+        .versionId("13-13-13-13")
+        .measureName("Test")
+        .measureMetaData(metaData)
+        .model(model)
+        .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+      anyString(), anyBoolean(), anyBoolean()))
+      .thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)).thenReturn(true);
+    when(measureRepository.save(any(Measure.class))).thenReturn(draftCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+      .thenReturn(true);
+
+    versionService.createDraft(
+      versionedMeasure.getId(), "Test", model, "test-user", TEST_ACCESS_TOKEN);
+
+    // testCaseSetIdExistsInSet must never be consulted when the flag is off
+    verify(measureRepository, never()).testCaseSetIdExistsInSet(anyString());
+  }
+
+  @Test
+  public void testCreateDraftSkipsTestCaseSetIdBackfillWhenSetIdsAlreadyExist() {
+    Measure versionedMeasure = buildBasicMeasure();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    Measure draftCopy =
+        versionedMeasure.toBuilder()
+            .id("2")
+            .versionId("13-13-13-13")
+            .measureName("Test")
+            .model(MODEL_QI_CORE)
+            .measureMetaData(metaData)
+            .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+            anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)).thenReturn(true);
+    // set IDs already present — no backfill required
+    when(measureRepository.testCaseSetIdExistsInSet(anyString())).thenReturn(true);
+    when(measureRepository.save(any(Measure.class))).thenReturn(draftCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+        .thenReturn(true);
+
+    versionService.createDraft(
+        versionedMeasure.getId(), "Test", MODEL_QI_CORE, "test-user", TEST_ACCESS_TOKEN);
+
+    // repository.save is called exactly once (for the draft itself, not for backfilling)
+    verify(measureRepository, times(1)).save(any(Measure.class));
+    // test cases on the original measure must not have been mutated with set ids
+    versionedMeasure.getTestCases().forEach(tc -> assertNull(tc.getTestCaseSetId()));
+  }
+
+  @Test
+  public void testCreateDraftBackfillsTestCaseSetIdsWhenFlagEnabledAndSetIdsAbsent() {
+    // Use a fresh test case with no testCaseSetId set
+    TestCase tcWithoutSetId =
+        TestCase.builder()
+            .id("tc-no-set-id")
+            .caseNumber(1)
+            .name("NoSetId")
+            .groupPopulations(List.of(testCaseGroupPopulation))
+            .build();
+    Measure versionedMeasure = buildBasicMeasure();
+    versionedMeasure.setTestCases(List.of(tcWithoutSetId));
+
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    Measure draftCopy =
+        versionedMeasure.toBuilder()
+            .id("2")
+            .versionId("13-13-13-13")
+            .measureName("Test")
+            .measureMetaData(metaData)
+            .model(MODEL_QI_CORE)
+            .testCases(List.of(tcWithoutSetId))
+            .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+            anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)).thenReturn(true);
+    // no set IDs present yet — backfill should run
+    when(measureRepository.testCaseSetIdExistsInSet(anyString())).thenReturn(false);
+    when(measureRepository.save(any(Measure.class))).thenReturn(draftCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+        .thenReturn(true);
+
+    versionService.createDraft(
+        versionedMeasure.getId(), "Test", MODEL_QI_CORE, "test-user", TEST_ACCESS_TOKEN);
+
+    // Each test case should now have a testCaseSetId assigned
+    versionedMeasure
+        .getTestCases()
+        .forEach(tc -> assertNotNull(tc.getTestCaseSetId(), "testCaseSetId should have been set"));
+
+    // save should be called twice: once for the backfill and once for the draft itself
+    verify(measureRepository, times(2)).save(any(Measure.class));
+  }
+
+  @Test
+  public void testCreateDraftDoesNotBackfillTestCaseSetIdsWhenTestCasesAreEmpty() {
+    Measure versionedMeasure = buildBasicMeasure();
+    versionedMeasure.setTestCases(List.of()); // no test cases
+
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    Measure draftCopy =
+        versionedMeasure.toBuilder()
+            .id("2")
+            .versionId("13-13-13-13")
+            .measureName("Test")
+            .measureMetaData(metaData)
+            .testCases(List.of())
+            .model(MODEL_QI_CORE)
+            .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+            anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(false);
+    when(appConfigService.isFlagEnabled(MadieFeatureFlag.TEST_CASE_SET_ID)).thenReturn(true);
+    // set IDs not present, but there are no test cases to backfill
+    when(measureRepository.testCaseSetIdExistsInSet(anyString())).thenReturn(false);
+    when(measureRepository.save(any(Measure.class))).thenReturn(draftCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+        .thenReturn(true);
+
+    versionService.createDraft(
+        versionedMeasure.getId(), "Test", MODEL_QI_CORE, "test-user", TEST_ACCESS_TOKEN);
+
+    // backfill save must not happen — only the draft save should occur
+    verify(measureRepository, times(1)).save(any(Measure.class));
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9869](https://jira.cms.gov/browse/MAT-9869)
(Optional) Related Tickets:

### Summary
- Back fill test case set ids to versioned measure if no test cases in the measure set have test case set ids 
- Carry over test case set IDs on measure draft creation

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
