### PR TITLE
MAT-9890: clean up compositeMeasureIds on component measures when com…

### DIFF
--- a/madie-checkstyle.xml
+++ b/madie-checkstyle.xml
@@ -12,7 +12,7 @@
 
     <!-- https://checkstyle.sourceforge.io/config_sizes.html#FileLength -->
     <module name="FileLength">
-        <property name="max" value="1020" />
+        <property name="max" value="1040" />
     </module>
 <module name="SuppressionFilter">
   <property name="file" value="suppressions.xml"/>

--- a/src/main/java/cms/gov/madie/measure/services/CompositeRelationshipService.java
+++ b/src/main/java/cms/gov/madie/measure/services/CompositeRelationshipService.java
@@ -1,0 +1,121 @@
+package cms.gov.madie.measure.services;
+
+import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import gov.cms.madie.models.common.ActionType;
+import gov.cms.madie.models.measure.Component;
+import gov.cms.madie.models.measure.Measure;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CompositeRelationshipService {
+
+  private final MeasureRepository measureRepository;
+  private final ActionLogService actionLogService;
+
+  public void syncComponents(
+      List<Component> previousComponents,
+      List<Component> newComponents,
+      Measure compositeMeasure,
+      String username) {
+
+    Set<String> previousIds =
+        previousComponents.stream().map(Component::getMeasureId).collect(Collectors.toSet());
+    Set<String> newIds =
+        newComponents == null
+            ? Set.of()
+            : newComponents.stream().map(Component::getMeasureId).collect(Collectors.toSet());
+
+    Set<String> addedIds =
+        newIds.stream().filter(id -> !previousIds.contains(id)).collect(Collectors.toSet());
+    Set<String> removedIds =
+        previousIds.stream().filter(id -> !newIds.contains(id)).collect(Collectors.toSet());
+
+    Set<String> allChangedIds = new HashSet<>(addedIds);
+    allChangedIds.addAll(removedIds);
+
+    String compositeMeasureId = compositeMeasure.getId();
+    String compositeName = compositeMeasure.getMeasureName();
+
+    // Fetch all added and removed components
+    Map<String, Measure> componentById =
+        measureRepository.findAllById(allChangedIds).stream()
+            .collect(Collectors.toMap(Measure::getId, m -> m));
+
+    // Validate that all component measures exist first
+    allChangedIds.forEach(
+        id -> {
+          if (!componentById.containsKey(id)) {
+            throw new ResourceNotFoundException("Measure", id);
+          }
+        });
+
+    // Update all components in memory before writing to db
+    addedIds.forEach(
+        id -> {
+          Measure component = componentById.get(id);
+          List<String> ids =
+              new ArrayList<>(
+                  Objects.requireNonNullElseGet(
+                      component.getCompositeMeasureIds(), ArrayList::new));
+          ids.add(compositeMeasureId);
+          component.setCompositeMeasureIds(ids);
+        });
+
+    removedIds.forEach(
+        id -> {
+          Measure component = componentById.get(id);
+          List<String> ids =
+              new ArrayList<>(
+                  Objects.requireNonNullElseGet(
+                      component.getCompositeMeasureIds(), ArrayList::new));
+          ids.remove(compositeMeasureId);
+          component.setCompositeMeasureIds(ids);
+        });
+
+    measureRepository.saveAll(componentById.values());
+
+    // Log after all writes succeed
+    addedIds.forEach(
+        id -> {
+          actionLogService.logAction(
+              compositeMeasureId,
+              Measure.class,
+              ActionType.COMPONENT_ADDED,
+              username,
+              "Added Component measure " + componentById.get(id).getMeasureName());
+          actionLogService.logAction(
+              id,
+              Measure.class,
+              ActionType.ADDED_TO_COMPOSITE,
+              username,
+              "Added to Composite measure " + compositeName);
+        });
+
+    removedIds.forEach(
+        id -> {
+          actionLogService.logAction(
+              compositeMeasureId,
+              Measure.class,
+              ActionType.COMPONENT_REMOVED,
+              username,
+              "Removed Component measure " + componentById.get(id).getMeasureName());
+          actionLogService.logAction(
+              id,
+              Measure.class,
+              ActionType.REMOVED_FROM_COMPOSITE,
+              username,
+              "Removed from Composite measure " + compositeName);
+        });
+  }
+}

--- a/src/main/java/cms/gov/madie/measure/services/GroupService.java
+++ b/src/main/java/cms/gov/madie/measure/services/GroupService.java
@@ -8,7 +8,6 @@ import cms.gov.madie.measure.utils.MeasureUtil;
 import cms.gov.madie.measure.validations.CqlDefinitionReturnTypeService;
 import cms.gov.madie.measure.validations.CqlObservationFunctionService;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import gov.cms.madie.models.common.ActionType;
 import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.measure.Component;
 import gov.cms.madie.models.measure.Group;
@@ -32,12 +31,9 @@ import org.springframework.util.CollectionUtils;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -55,6 +51,7 @@ public class GroupService {
   private final TestCaseLockService testCaseLockService;
   private final AppConfigService appConfigService;
   private final ActionLogService actionLogService;
+  private final CompositeRelationshipService compositeRelationshipService;
 
   public Group createOrUpdateGroup(Group group, String measureId, String username) {
 
@@ -142,7 +139,7 @@ public class GroupService {
     measureRepository.save(measure);
 
     if (MeasureScoring.COMPOSITE.toString().equalsIgnoreCase(group.getScoring())) {
-      updateComponentCompositeRelationship(
+      compositeRelationshipService.syncComponents(
           previousComponents, group.getComponents(), measure, username);
     }
 
@@ -249,7 +246,8 @@ public class GroupService {
         group -> {
           if (MeasureScoring.COMPOSITE.toString().equalsIgnoreCase(group.getScoring())
               && !CollectionUtils.isEmpty(group.getComponents())) {
-            updateComponentCompositeRelationship(group.getComponents(), List.of(), saved, username);
+            compositeRelationshipService.syncComponents(
+                group.getComponents(), List.of(), saved, username);
           }
         });
 
@@ -499,102 +497,6 @@ public class GroupService {
               .toList();
       testCase.setGroupPopulations(remainingGroups);
     }
-  }
-
-  private void updateComponentCompositeRelationship(
-      List<Component> previousComponents,
-      List<Component> newComponents,
-      Measure compositeMeasure,
-      String username) {
-
-    Set<String> previousIds =
-        previousComponents.stream().map(Component::getMeasureId).collect(Collectors.toSet());
-    Set<String> newIds =
-        newComponents == null
-            ? Set.of()
-            : newComponents.stream().map(Component::getMeasureId).collect(Collectors.toSet());
-
-    Set<String> addedIds =
-        newIds.stream().filter(id -> !previousIds.contains(id)).collect(Collectors.toSet());
-    Set<String> removedIds =
-        previousIds.stream().filter(id -> !newIds.contains(id)).collect(Collectors.toSet());
-
-    Set<String> allChangedIds = new HashSet<>(addedIds);
-    allChangedIds.addAll(removedIds);
-
-    String compositeMeasureId = compositeMeasure.getId();
-    String compositeName = compositeMeasure.getMeasureName();
-
-    // Fetch all added and removed components
-    Map<String, Measure> componentById =
-        measureRepository.findAllById(allChangedIds).stream()
-            .collect(Collectors.toMap(Measure::getId, m -> m));
-
-    // Validate that all component measures exist first
-    allChangedIds.forEach(
-        id -> {
-          if (!componentById.containsKey(id)) {
-            throw new ResourceNotFoundException("Measure", id);
-          }
-        });
-
-    // Update all components in memory before writing to db
-    addedIds.forEach(
-        id -> {
-          Measure component = componentById.get(id);
-          List<String> ids =
-              new ArrayList<>(
-                  Objects.requireNonNullElseGet(
-                      component.getCompositeMeasureIds(), ArrayList::new));
-          ids.add(compositeMeasureId);
-          component.setCompositeMeasureIds(ids);
-        });
-
-    removedIds.forEach(
-        id -> {
-          Measure component = componentById.get(id);
-          List<String> ids =
-              new ArrayList<>(
-                  Objects.requireNonNullElseGet(
-                      component.getCompositeMeasureIds(), ArrayList::new));
-          ids.remove(compositeMeasureId);
-          component.setCompositeMeasureIds(ids);
-        });
-
-    measureRepository.saveAll(componentById.values());
-
-    // Log after all writes succeed
-    addedIds.forEach(
-        id -> {
-          actionLogService.logAction(
-              compositeMeasureId,
-              Measure.class,
-              ActionType.COMPONENT_ADDED,
-              username,
-              "Added Component measure " + componentById.get(id).getMeasureName());
-          actionLogService.logAction(
-              id,
-              Measure.class,
-              ActionType.ADDED_TO_COMPOSITE,
-              username,
-              "Added to Composite measure " + compositeName);
-        });
-
-    removedIds.forEach(
-        id -> {
-          actionLogService.logAction(
-              compositeMeasureId,
-              Measure.class,
-              ActionType.COMPONENT_REMOVED,
-              username,
-              "Removed Component measure " + componentById.get(id).getMeasureName());
-          actionLogService.logAction(
-              id,
-              Measure.class,
-              ActionType.REMOVED_FROM_COMPOSITE,
-              username,
-              "Removed from Composite measure " + compositeName);
-        });
   }
 
   protected void handleFhirGroupReturnTypes(Group group, Measure measure) {

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -46,6 +46,7 @@ public class MeasureService extends BaseMeasureService {
   private final AppConfigService appConfigService;
   private final MeasureLockService measureLockService;
   private final UserServiceClient userServiceClient;
+  private final CompositeRelationshipService compositeRelationshipService;
 
   @Autowired
   public MeasureService(
@@ -60,7 +61,8 @@ public class MeasureService extends BaseMeasureService {
       TerminologyValidationService terminologyValidationService,
       AppConfigService appConfigService,
       MeasureLockService measureLockService,
-      UserServiceClient userServiceClient) {
+      UserServiceClient userServiceClient,
+      CompositeRelationshipService compositeRelationshipService) {
     // Pass parent dependencies to BaseMeasureService constructor
     super(measureRepository, measureSetService, appConfigService, measureLockService);
     // Assign child-specific fields
@@ -76,6 +78,7 @@ public class MeasureService extends BaseMeasureService {
     this.appConfigService = appConfigService;
     this.measureLockService = measureLockService;
     this.userServiceClient = userServiceClient;
+    this.compositeRelationshipService = compositeRelationshipService;
   }
 
   public void verifyAuthorizationByMeasureSetId(
@@ -364,6 +367,21 @@ public class MeasureService extends BaseMeasureService {
     existingMeasure.setVersionId(existingMeasure.getVersionId());
     existingMeasure.setMeasureSetId(existingMeasure.getMeasureSetId());
     Measure saveMeasure = measureRepository.save(existingMeasure);
+
+    if (existingMeasure.getMeasureMetaData().isComposite()
+        && !CollectionUtils.isEmpty(existingMeasure.getGroups())) {
+      List<Component> allComponents =
+          existingMeasure.getGroups().stream()
+              .filter(g -> MeasureScoring.COMPOSITE.toString().equalsIgnoreCase(g.getScoring()))
+              .filter(g -> !CollectionUtils.isEmpty(g.getComponents()))
+              .flatMap(g -> g.getComponents().stream())
+              .toList();
+      if (!allComponents.isEmpty()) {
+        compositeRelationshipService.syncComponents(
+            allComponents, List.of(), existingMeasure, username);
+      }
+    }
+
     actionLogService.logAction(id, Measure.class, ActionType.DELETED, username);
     measureLockService.unlockMeasure(id, username);
     return saveMeasure;

--- a/src/test/java/cms/gov/madie/measure/services/CompositeRelationshipServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/CompositeRelationshipServiceTest.java
@@ -1,0 +1,238 @@
+package cms.gov.madie.measure.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
+import cms.gov.madie.measure.repositories.MeasureRepository;
+import gov.cms.madie.models.common.ActionType;
+import gov.cms.madie.models.measure.Component;
+import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.MeasureMetaData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CompositeRelationshipServiceTest {
+
+  @Mock private MeasureRepository measureRepository;
+  @Mock private ActionLogService actionLogService;
+
+  @InjectMocks private CompositeRelationshipService compositeRelationshipService;
+
+  @Test
+  void testAddComponentAddsCompositeMeasureId() {
+    String componentMeasureId = "component-measure-id";
+    Measure componentMeasure =
+        Measure.builder().id(componentMeasureId).measureName("Component Measure").build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
+
+    compositeRelationshipService.syncComponents(
+        new ArrayList<>(),
+        List.of(Component.builder().measureId(componentMeasureId).build()),
+        compositeMeasure,
+        "test.user");
+
+    verify(measureRepository).saveAll(anyCollection());
+    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
+    assertEquals(1, savedIds.size());
+    assertTrue(savedIds.contains(compositeMeasure.getId()));
+
+    verify(actionLogService)
+        .logAction(
+            eq(compositeMeasure.getId()),
+            eq(Measure.class),
+            eq(ActionType.COMPONENT_ADDED),
+            eq("test.user"),
+            eq("Added Component measure Component Measure"));
+    verify(actionLogService)
+        .logAction(
+            eq(componentMeasureId),
+            eq(Measure.class),
+            eq(ActionType.ADDED_TO_COMPOSITE),
+            eq("test.user"),
+            eq("Added to Composite measure Composite Measure"));
+  }
+
+  @Test
+  void testAddComponentAlreadyInAnotherCompositeAppendsMeasureId() {
+    String componentMeasureId = "component-measure-id";
+    Measure componentMeasure =
+        Measure.builder()
+            .id(componentMeasureId)
+            .measureName("Component Measure")
+            .compositeMeasureIds(new ArrayList<>(List.of("other-measure-id")))
+            .build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
+
+    compositeRelationshipService.syncComponents(
+        new ArrayList<>(),
+        List.of(Component.builder().measureId(componentMeasureId).build()),
+        compositeMeasure,
+        "test.user");
+
+    verify(measureRepository).saveAll(anyCollection());
+    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
+    assertEquals(2, savedIds.size());
+    assertTrue(savedIds.contains("other-measure-id"));
+    assertTrue(savedIds.contains(compositeMeasure.getId()));
+
+    verify(actionLogService)
+        .logAction(
+            eq(compositeMeasure.getId()),
+            eq(Measure.class),
+            eq(ActionType.COMPONENT_ADDED),
+            eq("test.user"),
+            eq("Added Component measure Component Measure"));
+    verify(actionLogService)
+        .logAction(
+            eq(componentMeasureId),
+            eq(Measure.class),
+            eq(ActionType.ADDED_TO_COMPOSITE),
+            eq("test.user"),
+            eq("Added to Composite measure Composite Measure"));
+  }
+
+  @Test
+  void testAddComponentThrowsWhenComponentNotFound() {
+    String componentMeasureId = "component-measure-id";
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of());
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () ->
+            compositeRelationshipService.syncComponents(
+                new ArrayList<>(),
+                List.of(Component.builder().measureId(componentMeasureId).build()),
+                compositeMeasure,
+                "test.user"));
+  }
+
+  @Test
+  void testRemoveComponentNotInOtherCompositesRemovesMeasureId() {
+    String componentMeasureId = "component-measure-id";
+    Measure componentMeasure =
+        Measure.builder()
+            .id(componentMeasureId)
+            .measureName("Component Measure")
+            .compositeMeasureIds(new ArrayList<>(List.of("composite-measure-id")))
+            .build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
+
+    compositeRelationshipService.syncComponents(
+        List.of(Component.builder().measureId(componentMeasureId).build()),
+        new ArrayList<>(),
+        compositeMeasure,
+        "test.user");
+
+    verify(measureRepository).saveAll(anyCollection());
+    assertTrue(componentMeasure.getCompositeMeasureIds().isEmpty());
+
+    verify(actionLogService)
+        .logAction(
+            eq(compositeMeasure.getId()),
+            eq(Measure.class),
+            eq(ActionType.COMPONENT_REMOVED),
+            eq("test.user"),
+            eq("Removed Component measure Component Measure"));
+    verify(actionLogService)
+        .logAction(
+            eq(componentMeasureId),
+            eq(Measure.class),
+            eq(ActionType.REMOVED_FROM_COMPOSITE),
+            eq("test.user"),
+            eq("Removed from Composite measure Composite Measure"));
+  }
+
+  @Test
+  void testRemoveComponentStillInOtherCompositeRetainsMeasureId() {
+    String componentMeasureId = "component-measure-id";
+    Measure componentMeasure =
+        Measure.builder()
+            .id(componentMeasureId)
+            .measureName("Component Measure")
+            .compositeMeasureIds(
+                new ArrayList<>(List.of("composite-measure-id", "other-measure-id")))
+            .build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
+
+    compositeRelationshipService.syncComponents(
+        List.of(Component.builder().measureId(componentMeasureId).build()),
+        new ArrayList<>(),
+        compositeMeasure,
+        "test.user");
+
+    verify(measureRepository).saveAll(anyCollection());
+    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
+    assertEquals(1, savedIds.size());
+    assertFalse(savedIds.contains("composite-measure-id"));
+    assertTrue(savedIds.contains("other-measure-id"));
+
+    verify(actionLogService)
+        .logAction(
+            eq(compositeMeasure.getId()),
+            eq(Measure.class),
+            eq(ActionType.COMPONENT_REMOVED),
+            eq("test.user"),
+            eq("Removed Component measure Component Measure"));
+    verify(actionLogService)
+        .logAction(
+            eq(componentMeasureId),
+            eq(Measure.class),
+            eq(ActionType.REMOVED_FROM_COMPOSITE),
+            eq("test.user"),
+            eq("Removed from Composite measure Composite Measure"));
+  }
+}

--- a/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/GroupServiceTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -45,7 +44,6 @@ import cms.gov.madie.measure.utils.MeasureUtil;
 import cms.gov.madie.measure.utils.ResourceUtil;
 import cms.gov.madie.measure.validations.CqlDefinitionReturnTypeService;
 import cms.gov.madie.measure.validations.CqlObservationFunctionService;
-import gov.cms.madie.models.common.ActionType;
 import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.Version;
 
@@ -67,6 +65,7 @@ public class GroupServiceTest implements ResourceUtil {
   @Mock private TestCaseLockService testCaseLockService;
   @Mock private AppConfigService appConfigService;
   @Mock private ActionLogService actionLogService;
+  @Mock private CompositeRelationshipService compositeRelationshipService;
 
   @InjectMocks private GroupService groupService;
 
@@ -2046,10 +2045,8 @@ public class GroupServiceTest implements ResourceUtil {
   }
 
   @Test
-  void testAddComponentAddsCompositeMeasureId() {
+  void testAddComponentDelegatesToSyncComponents() {
     String componentMeasureId = "component-measure-id";
-    Measure componentMeasure =
-        Measure.builder().id(componentMeasureId).measureName("Component Measure").build();
 
     Group existingCompositeGroup =
         Group.builder()
@@ -2060,13 +2057,15 @@ public class GroupServiceTest implements ResourceUtil {
             .components(new ArrayList<>())
             .build();
 
+    List<Component> newComponents =
+        List.of(Component.builder().measureId(componentMeasureId).build());
     Group updatedCompositeGroup =
         Group.builder()
             .id("composite-group-id")
             .scoring(MeasureScoring.COMPOSITE.toString())
             .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
             .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
+            .components(newComponents)
             .build();
 
     Measure compositeMeasure =
@@ -2078,50 +2077,29 @@ public class GroupServiceTest implements ResourceUtil {
 
     when(measureRepository.findById(compositeMeasure.getId()))
         .thenReturn(Optional.of(compositeMeasure));
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
     when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     groupService.createOrUpdateGroup(updatedCompositeGroup, compositeMeasure.getId(), "test.user");
 
-    verify(measureRepository).saveAll(anyCollection());
-    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
-    assertEquals(1, savedIds.size());
-    assertTrue(savedIds.contains(compositeMeasure.getId()));
-
-    verify(actionLogService)
-        .logAction(
-            eq(compositeMeasure.getId()),
-            eq(Measure.class),
-            eq(ActionType.COMPONENT_ADDED),
-            eq("test.user"),
-            eq("Added Component measure Component Measure"));
-    verify(actionLogService)
-        .logAction(
-            eq(componentMeasureId),
-            eq(Measure.class),
-            eq(ActionType.ADDED_TO_COMPOSITE),
-            eq("test.user"),
-            eq("Added to Composite measure Composite Measure"));
+    verify(compositeRelationshipService)
+        .syncComponents(
+            eq(new ArrayList<>()), eq(newComponents), eq(compositeMeasure), eq("test.user"));
   }
 
   @Test
-  void testAddComponentAlreadyInAnotherCompositeAppendsMeasureId() {
+  void testRemoveComponentDelegatesToSyncComponents() {
     String componentMeasureId = "component-measure-id";
-    Measure componentMeasure =
-        Measure.builder()
-            .id(componentMeasureId)
-            .measureName("Component Measure")
-            .compositeMeasureIds(new ArrayList<>(List.of("other-measure-id")))
-            .build();
 
+    List<Component> existingComponents =
+        List.of(Component.builder().measureId(componentMeasureId).build());
     Group existingCompositeGroup =
         Group.builder()
             .id("composite-group-id")
             .scoring(MeasureScoring.COMPOSITE.toString())
             .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
             .populations(new ArrayList<>())
-            .components(new ArrayList<>())
+            .components(existingComponents)
             .build();
 
     Group updatedCompositeGroup =
@@ -2130,7 +2108,7 @@ public class GroupServiceTest implements ResourceUtil {
             .scoring(MeasureScoring.COMPOSITE.toString())
             .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
             .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
+            .components(new ArrayList<>())
             .build();
 
     Measure compositeMeasure =
@@ -2142,205 +2120,18 @@ public class GroupServiceTest implements ResourceUtil {
 
     when(measureRepository.findById(compositeMeasure.getId()))
         .thenReturn(Optional.of(compositeMeasure));
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
     when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
         .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
 
     groupService.createOrUpdateGroup(updatedCompositeGroup, compositeMeasure.getId(), "test.user");
 
-    verify(measureRepository).saveAll(anyCollection());
-    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
-    assertEquals(2, savedIds.size());
-    assertTrue(savedIds.contains("other-measure-id"));
-    assertTrue(savedIds.contains(compositeMeasure.getId()));
-
-    verify(actionLogService)
-        .logAction(
-            eq(compositeMeasure.getId()),
-            eq(Measure.class),
-            eq(ActionType.COMPONENT_ADDED),
-            eq("test.user"),
-            eq("Added Component measure Component Measure"));
-    verify(actionLogService)
-        .logAction(
-            eq(componentMeasureId),
-            eq(Measure.class),
-            eq(ActionType.ADDED_TO_COMPOSITE),
-            eq("test.user"),
-            eq("Added to Composite measure Composite Measure"));
+    verify(compositeRelationshipService)
+        .syncComponents(
+            eq(existingComponents), eq(new ArrayList<>()), eq(compositeMeasure), eq("test.user"));
   }
 
   @Test
-  void testAddComponentThrowsWhenComponentNotFound() {
-    String componentMeasureId = "component-measure-id";
-
-    Group existingCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(new ArrayList<>())
-            .build();
-
-    Group updatedCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
-            .build();
-
-    Measure compositeMeasure =
-        measure.toBuilder()
-            .measureName("Composite Measure")
-            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
-            .groups(new ArrayList<>(List.of(existingCompositeGroup)))
-            .build();
-
-    when(measureRepository.findById(compositeMeasure.getId()))
-        .thenReturn(Optional.of(compositeMeasure));
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of());
-    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
-        .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
-
-    assertThrows(
-        ResourceNotFoundException.class,
-        () ->
-            groupService.createOrUpdateGroup(
-                updatedCompositeGroup, compositeMeasure.getId(), "test.user"));
-  }
-
-  @Test
-  void testRemoveComponentNotInOtherCompositesRemovesMeasureId() {
-    String componentMeasureId = "component-measure-id";
-    Measure componentMeasure =
-        Measure.builder()
-            .id(componentMeasureId)
-            .measureName("Component Measure")
-            .compositeMeasureIds(new ArrayList<>(List.of(measure.getId())))
-            .build();
-
-    Group existingCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
-            .build();
-
-    Group updatedCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(new ArrayList<>())
-            .build();
-
-    Measure compositeMeasure =
-        measure.toBuilder()
-            .measureName("Composite Measure")
-            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
-            .groups(new ArrayList<>(List.of(existingCompositeGroup)))
-            .build();
-
-    when(measureRepository.findById(compositeMeasure.getId()))
-        .thenReturn(Optional.of(compositeMeasure));
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
-    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
-        .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
-
-    groupService.createOrUpdateGroup(updatedCompositeGroup, compositeMeasure.getId(), "test.user");
-
-    verify(measureRepository).saveAll(anyCollection());
-    assertTrue(componentMeasure.getCompositeMeasureIds().isEmpty());
-
-    verify(actionLogService)
-        .logAction(
-            eq(compositeMeasure.getId()),
-            eq(Measure.class),
-            eq(ActionType.COMPONENT_REMOVED),
-            eq("test.user"),
-            eq("Removed Component measure Component Measure"));
-    verify(actionLogService)
-        .logAction(
-            eq(componentMeasureId),
-            eq(Measure.class),
-            eq(ActionType.REMOVED_FROM_COMPOSITE),
-            eq("test.user"),
-            eq("Removed from Composite measure Composite Measure"));
-  }
-
-  @Test
-  void testRemoveComponentStillInOtherCompositeRetainsMeasureId() {
-    String componentMeasureId = "component-measure-id";
-    Measure componentMeasure =
-        Measure.builder()
-            .id(componentMeasureId)
-            .measureName("Component Measure")
-            .compositeMeasureIds(new ArrayList<>(List.of(measure.getId(), "other-measure-id")))
-            .build();
-
-    Group existingCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
-            .build();
-
-    Group updatedCompositeGroup =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
-            .populations(new ArrayList<>())
-            .components(new ArrayList<>())
-            .build();
-
-    Measure compositeMeasure =
-        measure.toBuilder()
-            .measureName("Composite Measure")
-            .measureMetaData(MeasureMetaData.builder().draft(true).composite(true).build())
-            .groups(new ArrayList<>(List.of(existingCompositeGroup)))
-            .build();
-
-    when(measureRepository.findById(compositeMeasure.getId()))
-        .thenReturn(Optional.of(compositeMeasure));
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
-    when(measureUtil.validateAllMeasureDependencies(any(Measure.class)))
-        .thenAnswer((invocationOnMock) -> invocationOnMock.getArgument(0));
-
-    groupService.createOrUpdateGroup(updatedCompositeGroup, compositeMeasure.getId(), "test.user");
-
-    verify(measureRepository).saveAll(anyCollection());
-    List<String> savedIds = componentMeasure.getCompositeMeasureIds();
-    assertEquals(1, savedIds.size());
-    assertFalse(savedIds.contains(measure.getId()));
-    assertTrue(savedIds.contains("other-measure-id"));
-
-    verify(actionLogService)
-        .logAction(
-            eq(compositeMeasure.getId()),
-            eq(Measure.class),
-            eq(ActionType.COMPONENT_REMOVED),
-            eq("test.user"),
-            eq("Removed Component measure Component Measure"));
-    verify(actionLogService)
-        .logAction(
-            eq(componentMeasureId),
-            eq(Measure.class),
-            eq(ActionType.REMOVED_FROM_COMPOSITE),
-            eq("test.user"),
-            eq("Removed from Composite measure Composite Measure"));
-  }
-
-  @Test
-  void testNonCompositeGroupDoesNotLogComponentActions() {
+  void testNonCompositeGroupDoesNotDelegateToCompositeRelationshipService() {
     Group nonCompositeGroup =
         Group.builder()
             .id(group1.getId())
@@ -2360,28 +2151,22 @@ public class GroupServiceTest implements ResourceUtil {
 
     groupService.createOrUpdateGroup(nonCompositeGroup, measureWithGroup.getId(), "test.user");
 
-    verify(actionLogService, times(0))
-        .logAction(anyString(), any(), any(ActionType.class), anyString(), anyString());
+    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
   }
 
   @Test
-  void testDeleteCompositeGroupRemovesGroupAndCleansUpComponentRelationships() {
+  void testDeleteCompositeGroupDelegatesToSyncComponents() {
     String componentMeasureId = "component-measure-id";
-    Measure componentMeasure =
-        Measure.builder()
-            .id(componentMeasureId)
-            .measureName("Component Measure")
-            .compositeMeasureIds(new ArrayList<>(List.of("composite-measure-id")))
-            .build();
-
     String groupId = "composite-group-id";
+
+    List<Component> components = List.of(Component.builder().measureId(componentMeasureId).build());
     Group compositeGroup =
         Group.builder()
             .id(groupId)
             .scoring(MeasureScoring.COMPOSITE.toString())
             .compositeScoring(CompositeMeasureScoring.OPPORTUNITY.toString())
             .populations(new ArrayList<>())
-            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
+            .components(components)
             .build();
 
     Measure compositeMeasure =
@@ -2396,32 +2181,16 @@ public class GroupServiceTest implements ResourceUtil {
 
     when(measureService.findMeasureById(compositeMeasure.getId())).thenReturn(compositeMeasure);
     when(measureRepository.save(any(Measure.class))).thenReturn(compositeMeasure);
-    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
 
     groupService.deleteMeasureGroup(compositeMeasure.getId(), groupId, "test.user");
 
-    verify(measureRepository).saveAll(anyCollection());
     assertTrue(compositeMeasure.getGroups().isEmpty());
-    assertTrue(componentMeasure.getCompositeMeasureIds().isEmpty());
-
-    verify(actionLogService)
-        .logAction(
-            eq(compositeMeasure.getId()),
-            eq(Measure.class),
-            eq(ActionType.COMPONENT_REMOVED),
-            eq("test.user"),
-            eq("Removed Component measure Component Measure"));
-    verify(actionLogService)
-        .logAction(
-            eq(componentMeasureId),
-            eq(Measure.class),
-            eq(ActionType.REMOVED_FROM_COMPOSITE),
-            eq("test.user"),
-            eq("Removed from Composite measure Composite Measure"));
+    verify(compositeRelationshipService)
+        .syncComponents(eq(components), eq(List.of()), eq(compositeMeasure), eq("test.user"));
   }
 
   @Test
-  void testDeleteNonCompositeGroupDoesNotLogComponentActions() {
+  void testDeleteNonCompositeGroupDoesNotDelegateToCompositeRelationshipService() {
     Group cohortGroup =
         Group.builder()
             .id("testgroupid")
@@ -2444,7 +2213,6 @@ public class GroupServiceTest implements ResourceUtil {
     groupService.deleteMeasureGroup("measure-id", "testgroupid", "test.user");
 
     assertTrue(existingMeasure.getGroups().isEmpty());
-    verify(actionLogService, times(0))
-        .logAction(anyString(), any(), any(ActionType.class), anyString(), anyString());
+    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -78,6 +78,7 @@ public class MeasureServiceTest implements ResourceUtil {
   @Mock private TerminologyValidationService terminologyValidationService;
   @Mock private MeasureLockService measureLockService;
   @Mock private UserServiceClient userServiceClient;
+  @Mock private CompositeRelationshipService compositeRelationshipService;
 
   @Spy @InjectMocks private MeasureService measureService;
   @Captor private ArgumentCaptor<Measure> measureArgumentCaptor;
@@ -2674,6 +2675,143 @@ public class MeasureServiceTest implements ResourceUtil {
     verify(measureRepository).save(measureArgumentCaptor.capture());
     Measure savedMeasure = measureArgumentCaptor.getValue();
     assertThat(savedMeasure.isActive(), is(false));
+  }
+
+  @Test
+  public void testDeactivateCompositeMeasureDelegatesToSyncComponents() {
+    // Given
+    String username = "test-user";
+    String componentMeasureId = "component-measure-id";
+
+    List<Component> components = List.of(Component.builder().measureId(componentMeasureId).build());
+    Group compositeGroup =
+        Group.builder()
+            .id("composite-group-id")
+            .scoring(MeasureScoring.COMPOSITE.toString())
+            .components(components)
+            .build();
+
+    MeasureMetaData compositeMeasureMetaData =
+        draftMeasureMetaData.toBuilder().composite(true).build();
+
+    Measure existingMeasure =
+        measure1.toBuilder()
+            .active(true)
+            .measureSet(MeasureSet.builder().owner(username).build())
+            .measureMetaData(compositeMeasureMetaData)
+            .groups(new ArrayList<>(List.of(compositeGroup)))
+            .build();
+
+    // When
+    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
+    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
+    when(actionLogService.logAction(
+            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
+        .thenReturn(true);
+    when(measureLockService.unlockMeasure(anyString(), anyString()))
+        .thenReturn(LockInfo.builder().build());
+
+    // Then
+    measureService.deactivateMeasure(existingMeasure.getId(), username);
+
+    verify(compositeRelationshipService)
+        .syncComponents(eq(components), eq(List.of()), eq(existingMeasure), eq(username));
+  }
+
+  @Test
+  public void testDeactivateCompositeMeasureWithEmptyGroupsDoesNotDelegate() {
+    // Given
+    String username = "test-user";
+
+    MeasureMetaData compositeMeasureMetaData =
+        draftMeasureMetaData.toBuilder().composite(true).build();
+
+    Measure existingMeasure =
+        measure1.toBuilder()
+            .active(true)
+            .measureSet(MeasureSet.builder().owner(username).build())
+            .measureMetaData(compositeMeasureMetaData)
+            .groups(new ArrayList<>())
+            .build();
+
+    // When
+    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
+    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
+    when(actionLogService.logAction(
+            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
+        .thenReturn(true);
+    when(measureLockService.unlockMeasure(anyString(), anyString()))
+        .thenReturn(LockInfo.builder().build());
+
+    // Then
+    measureService.deactivateMeasure(existingMeasure.getId(), username);
+
+    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
+  }
+
+  @Test
+  public void testDeactivateCompositeMeasureWithNoComponentsDoesNotDelegate() {
+    // Given
+    String username = "test-user";
+
+    Group compositeGroupNoComponents =
+        Group.builder()
+            .id("composite-group-id")
+            .scoring(MeasureScoring.COMPOSITE.toString())
+            .components(new ArrayList<>())
+            .build();
+
+    MeasureMetaData compositeMeasureMetaData =
+        draftMeasureMetaData.toBuilder().composite(true).build();
+
+    Measure existingMeasure =
+        measure1.toBuilder()
+            .active(true)
+            .measureSet(MeasureSet.builder().owner(username).build())
+            .measureMetaData(compositeMeasureMetaData)
+            .groups(new ArrayList<>(List.of(compositeGroupNoComponents)))
+            .build();
+
+    // When
+    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
+    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
+    when(actionLogService.logAction(
+            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
+        .thenReturn(true);
+    when(measureLockService.unlockMeasure(anyString(), anyString()))
+        .thenReturn(LockInfo.builder().build());
+
+    // Then
+    measureService.deactivateMeasure(existingMeasure.getId(), username);
+
+    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
+  }
+
+  @Test
+  public void testDeactivateNonCompositeMeasureDoesNotDelegate() {
+    // Given
+    String username = "test-user";
+
+    Measure existingMeasure =
+        measure1.toBuilder()
+            .active(true)
+            .measureSet(MeasureSet.builder().owner(username).build())
+            .measureMetaData(draftMeasureMetaData)
+            .build();
+
+    // When
+    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
+    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
+    when(actionLogService.logAction(
+            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
+        .thenReturn(true);
+    when(measureLockService.unlockMeasure(anyString(), anyString()))
+        .thenReturn(LockInfo.builder().build());
+
+    // Then
+    measureService.deactivateMeasure(existingMeasure.getId(), username);
+
+    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
   }
 
   @Test


### PR DESCRIPTION
…posite measure is deleted.

- Extract composite component tracking logic from GroupService into new CompositeRelationshipService to avoid circular dependency with MeasureService
- Call syncComponents in MeasureService.deactivateMeasure to remove deleted composite's ID from all component measures
- Now call syncComponents in GroupService when components are added/removed from a composite group or when a composite group is deleted

## MADiE PR

Jira Ticket: [MAT-9890](https://jira.cms.gov/browse/MAT-9890)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
