### PR TITLE
MAT-9891: clear compositeMeasureIds on draft of a measure

### DIFF
--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -268,6 +268,7 @@ public class VersionService {
     measureDraft.getMeasureMetaData().setVersionDate(null);
     measureDraft.setGroups(cloneMeasureGroups(measure.getGroups()));
     measureDraft.setReviewMetaData(new ReviewMetaData());
+    measureDraft.setCompositeMeasureIds(null);
     // back-fill test case set ids to versioned measure test cases and carry them over to draft
     backfillTestCaseSetIds(measure);
 

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -1234,6 +1234,36 @@ public class VersionServiceTest {
                 "Can not create a draft for the measure \"Test\". Only one draft is permitted per measure.")));
   }
 
+  @Test
+  public void testCreateDraftClearsCompositeMeasureIds() {
+    Measure versionedMeasure = buildBasicMeasure();
+    versionedMeasure.setCompositeMeasureIds(List.of("composite-id-1"));
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    Measure versionedCopy =
+        versionedMeasure.toBuilder()
+            .id("2")
+            .versionId("13-13-13-13")
+            .measureMetaData(metaData)
+            .build();
+
+    when(measureRepository.findById(anyString())).thenReturn(Optional.of(versionedMeasure));
+    when(measureRepository.existsByMeasureSetIdAndActiveAndMeasureMetaDataDraft(
+            anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(false);
+    when(measureRepository.save(any(Measure.class))).thenReturn(versionedCopy);
+    when(actionLogService.logAction(anyString(), any(), any(), anyString(), anyString()))
+        .thenReturn(true);
+
+    versionService.createDraft(
+        versionedMeasure.getId(), "Test", MODEL_QI_CORE, "test-user", TEST_ACCESS_TOKEN);
+
+    verify(measureRepository, times(1)).save(measureCaptor.capture());
+    Measure draft = measureCaptor.getValue();
+    assertNull(draft.getCompositeMeasureIds());
+    assertThat(versionedMeasure.getCompositeMeasureIds(), is(equalTo(List.of("composite-id-1"))));
+  }
+
   private Measure buildBasicMeasure() {
     return Measure.builder()
         .id("1")


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9891](https://jira.cms.gov/browse/MAT-9891)
(Optional) Related Tickets:

### Summary

- On draft creation, clear compositeMeasureIds so the new draft does not falsely indicate it is a component of any composite measure                                                                        
- On the other hand, the versioned measure's compositeMeasureIds remain unchanged

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
