### PR TITLE
MAT-9962 Allow invalid Patient references in test cases into test case execution.

### DIFF
--- a/src/main/java/cms/gov/madie/measure/resources/AdminController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/AdminController.java
@@ -13,6 +13,7 @@ import cms.gov.madie.measure.exceptions.*;
 import cms.gov.madie.measure.repositories.CqmMeasureRepository;
 import cms.gov.madie.measure.repositories.ExportRepository;
 import cms.gov.madie.measure.services.*;
+import cms.gov.madie.measure.utils.MeasureUtil;
 import gov.cms.madie.models.common.ModelType;
 import gov.cms.madie.models.common.Organization;
 import gov.cms.madie.models.common.Version;
@@ -224,6 +225,7 @@ public class AdminController extends AbstractMeasureController {
     targetQiCore6Measures.forEach(
         measure -> {
           if (CollectionUtils.isNotEmpty(measure.getTestCases())) {
+            boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
             measure
                 .getTestCases()
                 .forEach(
@@ -236,7 +238,8 @@ public class AdminController extends AbstractMeasureController {
                             measure.getId(),
                             testCase,
                             accessToken,
-                            ModelType.valueOfName(measure.getModel()));
+                            ModelType.valueOfName(measure.getModel()),
+                            lenientPatientRefs);
                       } else if (force
                           || testCase.getValidationStatus() == null
                           || TestCaseValidationStatus.VALIDATING
@@ -251,7 +254,8 @@ public class AdminController extends AbstractMeasureController {
                               measure.getId(),
                               testCase,
                               accessToken,
-                              ModelType.valueOfName(measure.getModel()));
+                              ModelType.valueOfName(measure.getModel()),
+                              lenientPatientRefs);
                         }
                       }
                     });

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -153,7 +153,8 @@ public class MeasureController extends AbstractMeasureController {
     final Measure existingMeasure = measureService.findMeasureById(id);
     checkMeasureLock(existingMeasure, username);
     Measure updatedMeasure =
-        measureService.updateMeasureTestCaseConfiguration(username, id, testCaseConfig);
+        measureService.updateMeasureTestCaseConfiguration(
+            username, id, testCaseConfig, accessToken);
     actionLogService.logAction(id, Measure.class, ActionType.UPDATED, username);
     return ResponseEntity.ok().body(updatedMeasure);
   }

--- a/src/main/java/cms/gov/madie/measure/resources/ValidationController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/ValidationController.java
@@ -41,11 +41,13 @@ public class ValidationController {
   public ResponseEntity<String> validateBundle(
       HttpEntity<String> request,
       @RequestParam String model,
+      @RequestParam(defaultValue = "false") boolean lenientPatientRefs,
       @RequestHeader("Authorization") String accessToken) {
     try {
       ModelType modelType = ModelType.valueOfName(model);
       ResponseEntity<HapiOperationOutcome> output =
-          fhirServicesClient.validateBundle(request.getBody(), modelType, accessToken);
+          fhirServicesClient.validateBundle(
+              request.getBody(), modelType, accessToken, lenientPatientRefs);
       return ResponseEntity.ok(mapper.writeValueAsString(output.getBody()));
 
     } catch (JsonProcessingException ex) {

--- a/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
+++ b/src/main/java/cms/gov/madie/measure/services/FhirServicesClient.java
@@ -71,7 +71,7 @@ public class FhirServicesClient {
   }
 
   public ResponseEntity<HapiOperationOutcome> validateBundle(
-      String testCaseJson, ModelType modelType, String accessToken) {
+      String testCaseJson, ModelType modelType, String accessToken, boolean lenientPatientRefs) {
     if (modelType == null) {
       throw new UnsupportedTypeException("Please provide model type.");
     }
@@ -81,6 +81,7 @@ public class FhirServicesClient {
         UriComponentsBuilder.fromUriString(
                 fhirServicesConfig.getMadieFhirServiceBaseUrl()
                     + fhirServicesConfig.getMadieFhirServiceValidateBundleUri())
+            .queryParam("lenientPatientRefs", lenientPatientRefs)
             .build(modelVersion);
     HttpHeaders headers = new HttpHeaders();
     headers.set(HttpHeaders.AUTHORIZATION, accessToken);

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -47,6 +47,7 @@ public class MeasureService extends BaseMeasureService {
   private final MeasureLockService measureLockService;
   private final UserServiceClient userServiceClient;
   private final CompositeRelationshipService compositeRelationshipService;
+  private final TestCaseValidationService testCaseValidationService;
 
   @Autowired
   public MeasureService(
@@ -62,7 +63,8 @@ public class MeasureService extends BaseMeasureService {
       AppConfigService appConfigService,
       MeasureLockService measureLockService,
       UserServiceClient userServiceClient,
-      CompositeRelationshipService compositeRelationshipService) {
+      CompositeRelationshipService compositeRelationshipService,
+      TestCaseValidationService testCaseValidationService) {
     // Pass parent dependencies to BaseMeasureService constructor
     super(measureRepository, measureSetService, appConfigService, measureLockService);
     // Assign child-specific fields
@@ -79,6 +81,7 @@ public class MeasureService extends BaseMeasureService {
     this.measureLockService = measureLockService;
     this.userServiceClient = userServiceClient;
     this.compositeRelationshipService = compositeRelationshipService;
+    this.testCaseValidationService = testCaseValidationService;
   }
 
   public void verifyAuthorizationByMeasureSetId(
@@ -200,7 +203,7 @@ public class MeasureService extends BaseMeasureService {
    * @return Updated measure
    */
   public Measure updateMeasureTestCaseConfiguration(
-      String username, String measureId, TestCaseConfiguration testCaseConfig) {
+      String username, String measureId, TestCaseConfiguration testCaseConfig, String accessToken) {
     if (measureId == null || measureId.isEmpty()) {
       log.error("updateMeasureTestCaseConfiguration:: Measure ID is null or empty");
       throw new InvalidIdException("Measure", "Update (PUT)", "(PUT [base]/[resource]/[id])");
@@ -217,6 +220,19 @@ public class MeasureService extends BaseMeasureService {
 
     Measure updatedMeasure =
         testCasePatchRepository.findAndModifyTestCaseConfig(testCaseConfig, measureId);
+    // on execute invalid test case config change, trigger the test case validation
+    if (MeasureUtil.isInvalidTestCaseExecutionEnabled(existingMeasure)
+        != testCaseConfig.isExecuteInvalidTestCases()) {
+      if (!ModelType.QDM_5_6.getValue().equalsIgnoreCase(existingMeasure.getModel())
+          && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
+        existingMeasure
+            .getTestCases()
+            .forEach(
+                testCase ->
+                    testCaseValidationService.validateResourceAsynchronously(
+                        updatedMeasure, testCase, TestCaseServiceUtil.SAVE, accessToken));
+      }
+    }
     log.info(
         "Measure ID {}, Test Case Configuration has been updated to [{}] by User : [{}] ",
         updatedMeasure.getId(),

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -215,22 +215,20 @@ public class MeasureService extends BaseMeasureService {
       throw new InvalidRequestException("TestCaseConfiguration cannot be null");
     }
     final Measure existingMeasure = findActiveMeasureById(measureId);
-
     verifyAuthorization(username, existingMeasure);
-
     Measure updatedMeasure =
         testCasePatchRepository.findAndModifyTestCaseConfig(testCaseConfig, measureId);
     // on execute invalid test case config change, trigger the test case validation
     if (MeasureUtil.isInvalidTestCaseExecutionEnabled(existingMeasure)
-        != testCaseConfig.isExecuteInvalidTestCases()
+            != testCaseConfig.isExecuteInvalidTestCases()
         && !ModelType.QDM_5_6.getValue().equalsIgnoreCase(existingMeasure.getModel())
         && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
-        existingMeasure
-            .getTestCases()
-            .forEach(
-                testCase ->
-                    testCaseValidationService.validateResourceAsynchronously(
-                        updatedMeasure, testCase, TestCaseServiceUtil.SAVE, accessToken));
+      existingMeasure
+          .getTestCases()
+          .forEach(
+              testCase ->
+                  testCaseValidationService.validateResourceAsynchronously(
+                      updatedMeasure, testCase, TestCaseServiceUtil.SAVE, accessToken));
     }
     log.info(
         "Measure ID {}, Test Case Configuration has been updated to [{}] by User : [{}] ",
@@ -685,9 +683,6 @@ public class MeasureService extends BaseMeasureService {
             measureSetMap.put(id, Boolean.TRUE);
           }
         });
-    // For measureSetIds that were searched, but not returned put the id & true ( is
-    // draftable )
-
     return measureSetMap;
   }
 
@@ -750,7 +745,6 @@ public class MeasureService extends BaseMeasureService {
   }
 
   public void deleteVersionedMeasures(List<Measure> measures) {
-
     List<Measure> versionedMeasures =
         measures.stream()
             .filter(
@@ -882,7 +876,6 @@ public class MeasureService extends BaseMeasureService {
     if (qiCoreMeasure == null || qdmMeasure == null) {
       throw new ResourceNotFoundException("CMS ID could not be associated. Please try again.");
     }
-
     verifyOneQiCoreAndOneQdmMeasure(qiCoreMeasure, qdmMeasure);
     verifyOwner(username, qiCoreMeasure, qdmMeasure);
     verifyQdmHasCmsId(qdmMeasure);

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -222,16 +222,15 @@ public class MeasureService extends BaseMeasureService {
         testCasePatchRepository.findAndModifyTestCaseConfig(testCaseConfig, measureId);
     // on execute invalid test case config change, trigger the test case validation
     if (MeasureUtil.isInvalidTestCaseExecutionEnabled(existingMeasure)
-        != testCaseConfig.isExecuteInvalidTestCases()) {
-      if (!ModelType.QDM_5_6.getValue().equalsIgnoreCase(existingMeasure.getModel())
-          && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
+        != testCaseConfig.isExecuteInvalidTestCases()
+        && !ModelType.QDM_5_6.getValue().equalsIgnoreCase(existingMeasure.getModel())
+        && !CollectionUtils.isEmpty(existingMeasure.getTestCases())) {
         existingMeasure
             .getTestCases()
             .forEach(
                 testCase ->
                     testCaseValidationService.validateResourceAsynchronously(
                         updatedMeasure, testCase, TestCaseServiceUtil.SAVE, accessToken));
-      }
     }
     log.info(
         "Measure ID {}, Test Case Configuration has been updated to [{}] by User : [{}] ",

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseService.java
@@ -116,9 +116,13 @@ public class TestCaseService {
     TestCaseServiceUtil.checkTestCaseSpecialCharacters(testCase);
     TestCase enrichedTestCase =
         enrichNewTestCase(testCase, username, measureId, measure.getModel());
+    boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
     enrichedTestCase =
         testCaseValidationService.validateTestCaseAsResource(
-            enrichedTestCase, ModelType.valueOfName(measure.getModel()), accessToken);
+            enrichedTestCase,
+            ModelType.valueOfName(measure.getModel()),
+            accessToken,
+            lenientPatientRefs);
 
     if (enrichedTestCase != null && !measure.getMeasureMetaData().isDraft()) {
       enrichedTestCase.setCreatedBeforeVersioning(false);
@@ -143,12 +147,13 @@ public class TestCaseService {
     }
     final Measure measure = measureService.findActiveMeasureById(measureId);
     List<TestCase> enrichedTestCases = new ArrayList<>(newTestCases.size());
+    boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
     for (TestCase testCase : newTestCases) {
       TestCaseServiceUtil.checkTestCaseSpecialCharacters(testCase);
       TestCase enriched = enrichNewTestCase(testCase, username, measureId, measure.getModel());
       enriched =
           testCaseValidationService.validateTestCaseAsResource(
-              enriched, ModelType.valueOfName(measure.getModel()), accessToken);
+              enriched, ModelType.valueOfName(measure.getModel()), accessToken, lenientPatientRefs);
       if (enriched != null && !measure.getMeasureMetaData().isDraft()) {
         enriched.setCreatedBeforeVersioning(false);
       }
@@ -220,8 +225,7 @@ public class TestCaseService {
   public List<TestCase> updateTestCaseValidResourcesForMeasure(
       Measure measure, final String accessToken) {
     List<TestCase> validatedTestCases =
-        testCaseValidationService.validateTestCasesAsResources(
-            measure.getTestCases(), ModelType.valueOfName(measure.getModel()), accessToken);
+        testCaseValidationService.validateTestCasesAsResources(measure, accessToken);
     measure.setTestCases(validatedTestCases);
     measureRepository.save(measure);
     return validatedTestCases;
@@ -288,9 +292,10 @@ public class TestCaseService {
   // common method 3 for two overloading updateTestCase() method
   private TestCase validateAndSave(
       TestCase testCase, Measure measure, String username, String accessToken) {
+    boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
     TestCase validatedTestCase =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.valueOfName(measure.getModel()), accessToken);
+            testCase, ModelType.valueOfName(measure.getModel()), accessToken, lenientPatientRefs);
     measure.getTestCases().add(validatedTestCase);
 
     measureRepository.save(measure); // TODO MAT-8921: Replace with Test Case FindAndModify
@@ -377,8 +382,9 @@ public class TestCaseService {
             : null);
 
     if (validate) {
+      boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
       return testCaseValidationService.validateTestCaseAsResource(
-          testCase, ModelType.valueOfName(measure.getModel()), accessToken);
+          testCase, ModelType.valueOfName(measure.getModel()), accessToken, lenientPatientRefs);
     }
     return testCase;
   }

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
@@ -201,6 +201,9 @@ public class TestCaseValidationService {
   public List<TestCase> validateTestCasesAsResources(
       final Measure measure, final String accessToken) {
     List<TestCase> validatedTestCases = new ArrayList<>();
+    if (measure == null) {
+      return validatedTestCases;
+    }
     List<TestCase> testCases = measure.getTestCases();
     ModelType modelType = ModelType.valueOfName(measure.getModel());
     boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
@@ -233,9 +233,14 @@ public class TestCaseValidationService {
     } else {
       final HapiOperationOutcome hapiOperationOutcome =
           validateTestCaseJson(testCase, modelType, accessToken, lenientPatientRefs);
+      boolean isValidResource = hapiOperationOutcome != null && hapiOperationOutcome.isSuccessful();
       return testCase.toBuilder()
           .hapiOperationOutcome(hapiOperationOutcome)
-          .validResource(hapiOperationOutcome != null && hapiOperationOutcome.isSuccessful())
+          .validResource(isValidResource)
+          .validationStatus(
+              isValidResource
+                  ? TestCaseValidationStatus.VALID.toString()
+                  : TestCaseValidationStatus.INVALID.toString())
           .build();
     }
   }

--- a/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
+++ b/src/main/java/cms/gov/madie/measure/services/TestCaseValidationService.java
@@ -3,6 +3,7 @@ package cms.gov.madie.measure.services;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import cms.gov.madie.measure.utils.JsonUtil;
+import cms.gov.madie.measure.utils.MeasureUtil;
 import cms.gov.madie.measure.utils.TestCaseServiceUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,7 +68,11 @@ public class TestCaseValidationService {
   }
 
   public void submitOnSaveValidationTask(
-      String measureId, TestCase testCase, String accessToken, ModelType modelType) {
+      String measureId,
+      TestCase testCase,
+      String accessToken,
+      ModelType modelType,
+      boolean lenientPatientRefs) {
     UUID taskId = UUID.randomUUID();
     log.info(
         "TestCase Validation::submit::{}::{}::{}::{}",
@@ -75,11 +80,16 @@ public class TestCaseValidationService {
         taskId,
         Instant.now(),
         saveExecutor.getQueueSize());
-    saveExecutor.submit(() -> validate(taskId, measureId, testCase, modelType, accessToken));
+    saveExecutor.submit(
+        () -> validate(taskId, measureId, testCase, modelType, accessToken, lenientPatientRefs));
   }
 
   public void submitOnImportValidationTask(
-      String measureId, TestCase testCase, String accessToken, ModelType modelType) {
+      String measureId,
+      TestCase testCase,
+      String accessToken,
+      ModelType modelType,
+      boolean lenientPatientRefs) {
     UUID taskId = UUID.randomUUID();
     log.info(
         "TestCase Validation Import Queue::submit::{}::{}::{}::{}",
@@ -87,7 +97,8 @@ public class TestCaseValidationService {
         taskId,
         Instant.now(),
         importExecutor.getQueueSize());
-    importExecutor.submit(() -> validate(taskId, measureId, testCase, modelType, accessToken));
+    importExecutor.submit(
+        () -> validate(taskId, measureId, testCase, modelType, accessToken, lenientPatientRefs));
   }
 
   void validate(
@@ -95,7 +106,8 @@ public class TestCaseValidationService {
       String measureId,
       TestCase submittedTestCase,
       ModelType modelType,
-      String accessToken) {
+      String accessToken,
+      boolean lenientPatientRefs) {
     // TODO replace with decorator
     Instant startTime = Instant.now();
     log.info(
@@ -121,7 +133,7 @@ public class TestCaseValidationService {
       // Consider putting a cache in front of madie-fhir-service's validation to quick return
       // duplicate requests based on the JSON hash.
       HapiOperationOutcome validationOutcome =
-          validateTestCaseJson(currentTestCase, modelType, accessToken);
+          validateTestCaseJson(currentTestCase, modelType, accessToken, lenientPatientRefs);
       measureRepository.findAndUpdateValidationResults(
           currentTestCase.getId(), measureId, taskId, validationOutcome);
       Instant stopTime = Instant.now();
@@ -149,7 +161,7 @@ public class TestCaseValidationService {
     Measure updatedMeasure =
         measureRepository.setValidationStatusToPending(testCase.getId(), measure.getId());
 
-    // If the measure is null, the test case has already has PENDING status.
+    // If the measure is null, the test case already has PENDING status.
     if (updatedMeasure == null) {
       log.info(
           "TestCase Validation::already pending::{}::measure::{}",
@@ -163,26 +175,42 @@ public class TestCaseValidationService {
             .filter((tc -> tc.getId().equals(testCase.getId())))
             .findFirst()
             .orElseThrow(() -> new ResourceNotFoundException("Test Case", testCase.getId()));
-
+    // for execute invalid test config, we want to allow patient reference validation to be lenient,
+    // meaning that if a patient resource has invalid references, present them as warnings and not
+    // error.
+    boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
     if (source.equals(TestCaseServiceUtil.SAVE)) {
       submitOnSaveValidationTask(
-          measure.getId(), updatedTestCase, accessToken, ModelType.valueOfName(measure.getModel()));
+          measure.getId(),
+          updatedTestCase,
+          accessToken,
+          ModelType.valueOfName(measure.getModel()),
+          lenientPatientRefs);
     } else if (source.equals(TestCaseServiceUtil.IMPORT)) {
       submitOnImportValidationTask(
-          measure.getId(), updatedTestCase, accessToken, ModelType.valueOfName(measure.getModel()));
+          measure.getId(),
+          updatedTestCase,
+          accessToken,
+          ModelType.valueOfName(measure.getModel()),
+          lenientPatientRefs);
     }
 
     return updatedTestCase; // Return testCase with pending status and set validationOutcome to null
   }
 
   public List<TestCase> validateTestCasesAsResources(
-      final List<TestCase> testCases, final ModelType modelType, final String accessToken) {
+      final Measure measure, final String accessToken) {
     List<TestCase> validatedTestCases = new ArrayList<>();
-
+    List<TestCase> testCases = measure.getTestCases();
+    ModelType modelType = ModelType.valueOfName(measure.getModel());
+    boolean lenientPatientRefs = MeasureUtil.isInvalidTestCaseExecutionEnabled(measure);
     if (!isEmpty(testCases)) {
       validatedTestCases =
           testCases.stream()
-              .map(testCase -> validateTestCaseAsResource(testCase, modelType, accessToken))
+              .map(
+                  testCase ->
+                      validateTestCaseAsResource(
+                          testCase, modelType, accessToken, lenientPatientRefs))
               .collect(Collectors.toList());
     }
 
@@ -190,7 +218,10 @@ public class TestCaseValidationService {
   }
 
   public TestCase validateTestCaseAsResource(
-      final TestCase testCase, final ModelType modelType, final String accessToken) {
+      final TestCase testCase,
+      final ModelType modelType,
+      final String accessToken,
+      boolean lenientPatientRefs) {
     if (testCase == null || StringUtils.isBlank(testCase.getJson())) {
       return testCase;
     }
@@ -198,7 +229,7 @@ public class TestCaseValidationService {
       return testCase.toBuilder().validResource(JsonUtil.isValidJson(testCase.getJson())).build();
     } else {
       final HapiOperationOutcome hapiOperationOutcome =
-          validateTestCaseJson(testCase, modelType, accessToken);
+          validateTestCaseJson(testCase, modelType, accessToken, lenientPatientRefs);
       return testCase.toBuilder()
           .hapiOperationOutcome(hapiOperationOutcome)
           .validResource(hapiOperationOutcome != null && hapiOperationOutcome.isSuccessful())
@@ -207,19 +238,19 @@ public class TestCaseValidationService {
   }
 
   HapiOperationOutcome validateTestCaseJson(
-      TestCase testCase, ModelType modelType, String accessToken) {
+      TestCase testCase, ModelType modelType, String accessToken, boolean lenientPatientRefs) {
     if (testCase == null || StringUtils.isBlank(testCase.getJson())) {
       return null;
     }
 
     try {
       return fhirServicesClient
-          .validateBundle(testCase.getJson(), modelType, accessToken)
+          .validateBundle(testCase.getJson(), modelType, accessToken, lenientPatientRefs)
           .getBody();
     } catch (HttpClientErrorException ex) {
       log.warn(
           "HAPI FHIR returned response code [{}] for testCaseId : {}",
-          ex.getRawStatusCode(),
+          ex.getStatusCode(),
           testCase.getId(),
           ex);
       try {

--- a/src/main/java/cms/gov/madie/measure/utils/MeasureUtil.java
+++ b/src/main/java/cms/gov/madie/measure/utils/MeasureUtil.java
@@ -292,4 +292,12 @@ public class MeasureUtil {
     }
     return null;
   }
+
+  public static boolean isInvalidTestCaseExecutionEnabled(Measure measure) {
+    TestCaseConfiguration testCaseConfiguration = measure.getTestCaseConfiguration();
+    if (testCaseConfiguration != null) {
+      return testCaseConfiguration.isExecuteInvalidTestCases();
+    }
+    return false;
+  }
 }

--- a/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
@@ -1046,7 +1046,8 @@ public class AdminControllerMvcTest {
             eq("M1"),
             eq(measure.getTestCases().get(0)),
             eq("test-okta"),
-            eq(ModelType.QI_CORE_6_0_0));
+            eq(ModelType.QI_CORE_6_0_0),
+            eq(false));
     assertEquals(
         TestCaseValidationStatus.PENDING.toString(),
         measure.getTestCases().get(0).getValidationStatus());
@@ -1084,7 +1085,7 @@ public class AdminControllerMvcTest {
 
     verify(testCaseValidationService, times(1))
         .submitOnImportValidationTask(
-            eq("M1"), any(TestCase.class), eq("test-okta"), eq(ModelType.QI_CORE_6_0_0));
+            eq("M1"), any(TestCase.class), eq("test-okta"), eq(ModelType.QI_CORE_6_0_0), eq(false));
   }
 
   @Test
@@ -1120,7 +1121,7 @@ public class AdminControllerMvcTest {
 
     verify(testCaseValidationService, never())
         .submitOnImportValidationTask(
-            anyString(), any(TestCase.class), anyString(), any(ModelType.class));
+            anyString(), any(TestCase.class), anyString(), any(ModelType.class), anyBoolean());
   }
 
   @Test
@@ -1228,13 +1229,15 @@ public class AdminControllerMvcTest {
             eq("M1"),
             eq(measure.getTestCases().get(1)),
             eq("test-okta"),
-            eq(ModelType.QI_CORE_6_0_0));
+            eq(ModelType.QI_CORE_6_0_0),
+            eq(false));
     verify(testCaseValidationService, never())
         .submitOnImportValidationTask(
             eq("M1"),
             eq(measure.getTestCases().get(2)),
             eq("test-okta"),
-            eq(ModelType.QI_CORE_6_0_0));
+            eq(ModelType.QI_CORE_6_0_0),
+            eq(false));
 
     assertEquals(
         TestCaseValidationStatus.PENDING.toString(),

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerTest.java
@@ -1067,7 +1067,7 @@ class MeasureControllerTest {
     TestCaseConfiguration testCaseConfig = new TestCaseConfiguration();
 
     when(measureService.updateMeasureTestCaseConfiguration(
-            "test.user", "measureId", testCaseConfig))
+            "test.user", "measureId", testCaseConfig, "Bearer TOKEN"))
         .thenReturn(updatedMeasure);
 
     ResponseEntity<Measure> response =
@@ -1077,7 +1077,8 @@ class MeasureControllerTest {
     assertNotNull(response.getBody());
     assertEquals(updatedMeasure, response.getBody());
     verify(measureService, times(1))
-        .updateMeasureTestCaseConfiguration("test.user", "measureId", testCaseConfig);
+        .updateMeasureTestCaseConfiguration(
+            "test.user", "measureId", testCaseConfig, "Bearer TOKEN");
     verify(actionLogService, times(1))
         .logAction("measureId", Measure.class, ActionType.UPDATED, "test.user");
   }
@@ -1092,7 +1093,8 @@ class MeasureControllerTest {
 
     doThrow(new UnauthorizedException("Measure", "measureId", "invalid.user"))
         .when(measureService)
-        .updateMeasureTestCaseConfiguration("invalid.user", "measureId", testCaseConfig);
+        .updateMeasureTestCaseConfiguration(
+            "invalid.user", "measureId", testCaseConfig, "Bearer TOKEN");
 
     assertThrows(
         UnauthorizedException.class,

--- a/src/test/java/cms/gov/madie/measure/resources/ValidationControllerTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/ValidationControllerTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -60,14 +61,16 @@ class ValidationControllerTest {
     final String goodOutcomeJson = "{ \"code\": 200, \"successful\": true }";
     HttpEntity<String> request = new HttpEntity<>(testCaseJson, headers);
 
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(
             ResponseEntity.ok(HapiOperationOutcome.builder().code(200).successful(true).build()));
 
     when(mapper.writeValueAsString(any())).thenReturn(goodOutcomeJson);
 
     ResponseEntity<String> output =
-        validationController.validateBundle(request, ModelType.QI_CORE.getValue(), accessToken);
+        validationController.validateBundle(
+            request, ModelType.QI_CORE.getValue(), false, accessToken);
 
     assertThat(output, is(notNullValue()));
     assertThat(output.getBody(), is(notNullValue()));
@@ -76,7 +79,8 @@ class ValidationControllerTest {
         .validateBundle(
             testCaseJsonCaptor.capture(),
             testCaseModelCaptor.capture(),
-            accessTokenCaptor.capture());
+            accessTokenCaptor.capture(),
+            anyBoolean());
     assertThat(testCaseJsonCaptor.getValue(), is(equalTo(testCaseJson)));
     assertThat(accessTokenCaptor.getValue(), is(equalTo(accessToken)));
   }
@@ -88,14 +92,16 @@ class ValidationControllerTest {
     HttpHeaders headers = new HttpHeaders();
     HttpEntity<String> request = new HttpEntity<>(testCaseJson, headers);
 
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(
             ResponseEntity.ok(HapiOperationOutcome.builder().code(200).successful(true).build()));
 
     when(mapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("BadJson") {});
 
     ResponseEntity<String> output =
-        validationController.validateBundle(request, ModelType.QI_CORE.getValue(), accessToken);
+        validationController.validateBundle(
+            request, ModelType.QI_CORE.getValue(), false, accessToken);
 
     assertThat(output, is(notNullValue()));
     assertThat(output.getStatusCode(), is(HttpStatus.BAD_REQUEST));
@@ -110,7 +116,8 @@ class ValidationControllerTest {
         .validateBundle(
             testCaseJsonCaptor.capture(),
             testCaseModelCaptor.capture(),
-            accessTokenCaptor.capture());
+            accessTokenCaptor.capture(),
+            anyBoolean());
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/FhirServicesClientTest.java
@@ -121,7 +121,8 @@ class FhirServicesClientTest {
         .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
     assertThrows(
         HttpClientErrorException.class,
-        () -> fhirServicesClient.validateBundle(testCaseJson, ModelType.QI_CORE, accessToken));
+        () ->
+            fhirServicesClient.validateBundle(testCaseJson, ModelType.QI_CORE, accessToken, false));
     verify(fhirServicesConfig.fhirServicesRestTemplate(), times(1))
         .exchange(
             any(URI.class), eq(HttpMethod.POST), httpEntityCaptor.capture(), any(Class.class));
@@ -145,7 +146,7 @@ class FhirServicesClientTest {
             .exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class), any(Class.class)))
         .thenReturn(ResponseEntity.ok(goodOutcome));
     ResponseEntity<HapiOperationOutcome> output =
-        fhirServicesClient.validateBundle(testCaseJson, ModelType.QI_CORE, accessToken);
+        fhirServicesClient.validateBundle(testCaseJson, ModelType.QI_CORE, accessToken, false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getBody(), is(notNullValue()));
     assertThat(output.getBody(), is(equalTo(goodOutcome)));
@@ -209,7 +210,7 @@ class FhirServicesClientTest {
     Exception ex =
         assertThrows(
             UnsupportedTypeException.class,
-            () -> fhirServicesClient.validateBundle("test case json", null, accessToken));
+            () -> fhirServicesClient.validateBundle("test case json", null, accessToken, false));
     assertThat(ex.getMessage(), is(equalTo("Please provide model type.")));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -2321,7 +2321,8 @@ public class MeasureServiceTest implements ResourceUtil {
     assertNotNull(result);
     assertEquals(updatedMeasure, result);
     verify(testCaseValidationService, times(2))
-        .validateResourceAsynchronously(eq(updatedMeasure), any(TestCase.class), anyString(), eq(ACCESS_TOKEN));
+        .validateResourceAsynchronously(
+            eq(updatedMeasure), any(TestCase.class), anyString(), eq(ACCESS_TOKEN));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -79,6 +79,7 @@ public class MeasureServiceTest implements ResourceUtil {
   @Mock private MeasureLockService measureLockService;
   @Mock private UserServiceClient userServiceClient;
   @Mock private CompositeRelationshipService compositeRelationshipService;
+  @Mock private TestCaseValidationService testCaseValidationService;
 
   @Spy @InjectMocks private MeasureService measureService;
   @Captor private ArgumentCaptor<Measure> measureArgumentCaptor;
@@ -2284,6 +2285,43 @@ public class MeasureServiceTest implements ResourceUtil {
     verify(measureService, times(1)).verifyAuthorization(username, existingMeasure);
     verify(testCasePatchRepository, times(1))
         .findAndModifyTestCaseConfig(testCaseConfig, measureId);
+  }
+
+  @Test
+  void triggerTestCaseValidationOnExecuteInvalidTestCasesChange() {
+    String username = "testUser";
+    String measureId = "testMeasureId";
+    // existing measure has executeInvalidTestCases = false (default)
+    TestCase testCase1 = TestCase.builder().id("tc1").build();
+    TestCase testCase2 = TestCase.builder().id("tc2").build();
+    Measure existingMeasure =
+        Measure.builder()
+            .id(measureId)
+            .model(ModelType.QI_CORE.getValue())
+            .measureMetaData(MeasureMetaData.builder().draft(true).build())
+            .testCaseConfiguration(
+                TestCaseConfiguration.builder().executeInvalidTestCases(false).build())
+            .testCases(List.of(testCase1, testCase2))
+            .build();
+    // new config sets executeInvalidTestCases = true (change triggers validation)
+    TestCaseConfiguration testCaseConfig =
+        TestCaseConfiguration.builder().executeInvalidTestCases(true).build();
+    Measure updatedMeasure = Measure.builder().id(measureId).build();
+
+    when(measureRepository.findByIdAndActive(measureId, true))
+        .thenReturn(Optional.of(existingMeasure));
+    doNothing().when(measureService).verifyAuthorization(username, existingMeasure);
+    when(testCasePatchRepository.findAndModifyTestCaseConfig(testCaseConfig, measureId))
+        .thenReturn(updatedMeasure);
+
+    Measure result =
+        measureService.updateMeasureTestCaseConfiguration(
+            username, measureId, testCaseConfig, ACCESS_TOKEN);
+
+    assertNotNull(result);
+    assertEquals(updatedMeasure, result);
+    verify(testCaseValidationService, times(2))
+        .validateResourceAsynchronously(eq(updatedMeasure), any(TestCase.class), anyString(), eq(ACCESS_TOKEN));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -2276,7 +2276,8 @@ public class MeasureServiceTest implements ResourceUtil {
         .thenReturn(updatedMeasure);
 
     Measure result =
-        measureService.updateMeasureTestCaseConfiguration(username, measureId, testCaseConfig);
+        measureService.updateMeasureTestCaseConfiguration(
+            username, measureId, testCaseConfig, ACCESS_TOKEN);
 
     assertNotNull(result);
     assertEquals(updatedMeasure, result);
@@ -2292,7 +2293,9 @@ public class MeasureServiceTest implements ResourceUtil {
 
     assertThrows(
         InvalidIdException.class,
-        () -> measureService.updateMeasureTestCaseConfiguration(username, null, testCaseConfig));
+        () ->
+            measureService.updateMeasureTestCaseConfiguration(
+                username, null, testCaseConfig, ACCESS_TOKEN));
   }
 
   @Test
@@ -2302,7 +2305,9 @@ public class MeasureServiceTest implements ResourceUtil {
 
     assertThrows(
         InvalidIdException.class,
-        () -> measureService.updateMeasureTestCaseConfiguration(username, "", testCaseConfig));
+        () ->
+            measureService.updateMeasureTestCaseConfiguration(
+                username, "", testCaseConfig, ACCESS_TOKEN));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseServiceTest.java
@@ -122,7 +122,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureRepository.addOrUpdateTestCase(anyString(), any(TestCase.class)))
         .thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase persistTestCase =
@@ -164,7 +164,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .thenReturn(measure);
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -467,7 +467,7 @@ public class TestCaseServiceTest implements ResourceUtil {
             .build();
     doReturn(List.of(validatedTestCase))
         .when(testCaseValidationService)
-        .validateTestCasesAsResources(anyList(), any(ModelType.class), anyString());
+        .validateTestCasesAsResources(any(Measure.class), anyString());
 
     List<TestCase> output =
         testCaseService.updateTestCaseValidResourcesForMeasure(measure, accessToken);
@@ -581,7 +581,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     measure.getMeasureMetaData().setDraft(false);
     when(measureService.findActiveMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
     Mockito.doAnswer((args) -> args.getArgument(0))
@@ -623,7 +623,7 @@ public class TestCaseServiceTest implements ResourceUtil {
   @Test
   public void testPersistTestCasesHandlesListToMeasureNoExistingTestCases() {
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -686,7 +686,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     String accessToken = "Bearer Token";
     when(measureService.findActiveMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     List<TestCase> output =
@@ -734,7 +734,7 @@ public class TestCaseServiceTest implements ResourceUtil {
 
     when(measureService.findActiveMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -778,7 +778,8 @@ public class TestCaseServiceTest implements ResourceUtil {
     assertThat(output.get(1).isCreatedBeforeVersioning(), is(false));
 
     verify(testCaseValidationService, times(2))
-        .validateTestCaseAsResource(any(TestCase.class), any(ModelType.class), anyString());
+        .validateTestCaseAsResource(
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean());
   }
 
   @Test
@@ -786,7 +787,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     measure.setMeasureMetaData(MeasureMetaData.builder().draft(false).build());
     when(measureService.findActiveMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     when(measureRepository.addOrUpdateTestCase(anyString(), any(TestCase.class)))
         .thenReturn(measure);
@@ -949,7 +950,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase updatedTestCase =
@@ -1014,7 +1015,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase updatedTestCase =
@@ -1064,7 +1065,7 @@ public class TestCaseServiceTest implements ResourceUtil {
             .build();
     when(measureService.findMeasureById(anyString())).thenReturn(originalMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase updatingTestCase =
@@ -1140,7 +1141,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .save(any(Measure.class));
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase updatedTestCase =
@@ -1160,7 +1161,7 @@ public class TestCaseServiceTest implements ResourceUtil {
   public void testUpdateTestCaseSucceedsForNonDraftMeasure() {
     when(measureService.findMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     measure.setMeasureMetaData(MeasureMetaData.builder().draft(false).build());
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
@@ -1185,7 +1186,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase upsertingTestCase =
@@ -1225,7 +1226,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase upsertingTestCase =
@@ -1271,7 +1272,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase upsertingTestCase =
@@ -1341,7 +1342,7 @@ public class TestCaseServiceTest implements ResourceUtil {
   @Test
   public void testGetTestCaseReturnsTestCaseByIdValidatesByUpsert() {
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(
             testCase.toBuilder()
                 .hapiOperationOutcome(
@@ -2061,7 +2062,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(measure);
     when(measureService.findMeasureById(anyString())).thenReturn(measure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -2629,7 +2630,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .when(measureRepository)
         .save(any(Measure.class));
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase updatedTestCase =
@@ -2669,7 +2670,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .thenReturn(measure);
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     TestCase persistTestCase =
@@ -3063,7 +3064,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3163,7 +3164,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3260,7 +3261,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3321,7 +3322,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3397,7 +3398,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3430,7 +3431,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3534,7 +3535,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3630,7 +3631,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(
             invocation ->
                 (invocation.getArgument(0, TestCase.class))
@@ -3671,7 +3672,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .thenReturn(targetMeasure);
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
 
     // Copy single Test Case to target measure
@@ -3696,7 +3697,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     when(measureRepository.addOrUpdateTestCase(anyString(), any(TestCase.class)))
         .thenReturn(targetMeasure);
@@ -3730,7 +3731,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     when(measureRepository.addOrUpdateTestCase(anyString(), any(TestCase.class)))
         .thenReturn(targetMeasure);
@@ -3767,7 +3768,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(measureService.findActiveMeasureById(anyString())).thenReturn(targetMeasure);
     when(measureService.findMeasureById(anyString())).thenReturn(targetMeasure);
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     when(measureRepository.addOrUpdateTestCase(anyString(), any(TestCase.class)))
         .thenReturn(targetMeasure);
@@ -4029,7 +4030,7 @@ public class TestCaseServiceTest implements ResourceUtil {
     when(testCaseLockService.findByTestCaseId(anyString())).thenReturn(null);
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     measure.setMeasureMetaData(MeasureMetaData.builder().draft(false).build());
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);
@@ -4050,7 +4051,7 @@ public class TestCaseServiceTest implements ResourceUtil {
         .thenReturn(TestCaseLock.builder().lockedBy("test.user").build());
 
     when(testCaseValidationService.validateTestCaseAsResource(
-            any(TestCase.class), any(ModelType.class), anyString()))
+            any(TestCase.class), any(ModelType.class), anyString(), anyBoolean()))
         .thenAnswer(invocation -> invocation.getArgument(0, TestCase.class));
     measure.setMeasureMetaData(MeasureMetaData.builder().draft(false).build());
     ArgumentCaptor<Measure> measureCaptor = ArgumentCaptor.forClass(Measure.class);

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseValidationServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseValidationServiceTest.java
@@ -385,7 +385,6 @@ public class TestCaseValidationServiceTest {
   @Test
   public void testValidateTestCasesAsResourcesNullList() {
     final String accessToken = "Bearer Token";
-    final ModelType model = ModelType.QI_CORE;
     List<TestCase> output =
         testCaseValidationService.validateTestCasesAsResources(null, accessToken);
     assertThat(output, is(notNullValue()));
@@ -395,7 +394,6 @@ public class TestCaseValidationServiceTest {
   @Test
   public void testValidateTestCasesAsResourcesEmptyList() {
     final String accessToken = "Bearer Token";
-    final ModelType model = ModelType.QI_CORE;
     final List<TestCase> testCases = List.of();
     final TestCaseConfiguration configuration = TestCaseConfiguration.builder().build();
     Measure measure =
@@ -510,8 +508,8 @@ public class TestCaseValidationServiceTest {
             eq(measure.getId()),
             eq(measure.getTestCases().get(0)),
             eq(ModelType.QI_CORE_6_0_0),
-            anyString(),
-            false);
+            eq("Bearer Token"),
+            eq(false));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/TestCaseValidationServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/TestCaseValidationServiceTest.java
@@ -137,11 +137,17 @@ public class TestCaseValidationServiceTest {
     when(measureRepository.findAndUpdateValidationResults(
             anyString(), anyString(), any(UUID.class), any(HapiOperationOutcome.class)))
         .thenReturn(validTestCaseMeasure);
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(hapiValidOutcome);
 
     testCaseValidationService.validate(
-        UUID.randomUUID(), measure.getId(), testCase, ModelType.QI_CORE_6_0_0, "Bearer Token");
+        UUID.randomUUID(),
+        measure.getId(),
+        testCase,
+        ModelType.QI_CORE_6_0_0,
+        "Bearer Token",
+        false);
     //        assertThat(
     //            testCase.getTestCaseValidationStatus(), equalTo(TestCaseValidationStatus.VALID));
   }
@@ -155,13 +161,14 @@ public class TestCaseValidationServiceTest {
             .build();
     final String accessToken = "Bearer Token";
 
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(
             ResponseEntity.ok(HapiOperationOutcome.builder().code(200).successful(true).build()));
 
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QI_CORE, accessToken);
+            testCase, ModelType.QI_CORE, accessToken, false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getJson(), is(notNullValue()));
     assertThat(output.getHapiOperationOutcome(), is(notNullValue()));
@@ -181,11 +188,11 @@ public class TestCaseValidationServiceTest {
 
     doThrow(new RuntimeException())
         .when(fhirServicesClient)
-        .validateBundle(anyString(), any(ModelType.class), anyString());
+        .validateBundle(anyString(), any(ModelType.class), anyString(), anyBoolean());
 
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QI_CORE, "Bearer Token");
+            testCase, ModelType.QI_CORE, "Bearer Token", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getHapiOperationOutcome(), is(notNullValue()));
     assertThat(output.getHapiOperationOutcome().getCode(), is(equalTo(500)));
@@ -201,7 +208,7 @@ public class TestCaseValidationServiceTest {
     final String accessToken = "Bearer Token";
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QDM_5_6, accessToken);
+            testCase, ModelType.QDM_5_6, accessToken, false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getJson(), is(notNullValue()));
     assertThat(output.isValidResource(), is(true));
@@ -214,7 +221,7 @@ public class TestCaseValidationServiceTest {
     final String accessToken = "Bearer Token";
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QDM_5_6, accessToken);
+            testCase, ModelType.QDM_5_6, accessToken, false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getJson(), is(notNullValue()));
     assertThat(output.isValidResource(), is(false));
@@ -226,7 +233,7 @@ public class TestCaseValidationServiceTest {
     TestCase testCase = TestCase.builder().id("TestID").build();
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QDM_5_6, accessToken);
+            testCase, ModelType.QDM_5_6, accessToken, false);
     assertEquals(testCase, output);
   }
 
@@ -237,14 +244,14 @@ public class TestCaseValidationServiceTest {
 
     TestCase output =
         testCaseValidationService.validateTestCaseAsResource(
-            testCase, ModelType.QI_CORE, accessToken);
+            testCase, ModelType.QI_CORE, accessToken, false);
     assertThat(output, is(nullValue()));
   }
 
   @Test
   public void testValidateTestCaseJsonHandlesNullTestCase() {
     HapiOperationOutcome output =
-        testCaseValidationService.validateTestCaseJson(null, ModelType.QI_CORE, "TOKEN");
+        testCaseValidationService.validateTestCaseJson(null, ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(nullValue()));
   }
 
@@ -253,7 +260,7 @@ public class TestCaseValidationServiceTest {
     TestCase tc = new TestCase();
     tc.setJson(null);
     HapiOperationOutcome output =
-        testCaseValidationService.validateTestCaseJson(tc, ModelType.QI_CORE, "TOKEN");
+        testCaseValidationService.validateTestCaseJson(tc, ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(nullValue()));
   }
 
@@ -261,7 +268,7 @@ public class TestCaseValidationServiceTest {
   public void testValidateTestCaseJsonHandlesEmptyJson() {
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(nullValue()));
   }
 
@@ -269,39 +276,42 @@ public class TestCaseValidationServiceTest {
   public void testValidateTestCaseJsonHandlesWhitespaceJson() {
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("   ").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("   ").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(nullValue()));
   }
 
   @Test
   public void testValidateTestCaseJsonHandlesGenericException() {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(new RuntimeException("something bad happened!"));
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(500)));
   }
 
   @Test
   public void testValidateTestCaseJsonHandlesNotFound() {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(
             new HttpClientErrorException(
                 HttpStatus.NOT_FOUND, "path not found", "{}".getBytes(), Charset.defaultCharset()));
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(404)));
   }
 
   @Test
   public void testValidateTestCaseJsonHandlesUnsupportedMediaType() {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(
             new HttpClientErrorException(
                 HttpStatus.UNSUPPORTED_MEDIA_TYPE,
@@ -311,21 +321,22 @@ public class TestCaseValidationServiceTest {
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(415)));
   }
 
   @Test
   public void testValidateTestCaseJsonHandlesInternalServerError() {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(
             new HttpClientErrorException(
                 HttpStatus.INTERNAL_SERVER_ERROR, "Unsupported Media Type"));
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(500)));
   }
@@ -333,7 +344,8 @@ public class TestCaseValidationServiceTest {
   @Test
   public void testValidateTestCaseJsonHandlesProcessingErrorDuringHttpClientException()
       throws JsonProcessingException {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(
             new HttpClientErrorException(
                 HttpStatus.INTERNAL_SERVER_ERROR, "Unsupported Media Type"));
@@ -345,7 +357,7 @@ public class TestCaseValidationServiceTest {
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(500)));
     assertThat(
@@ -357,12 +369,13 @@ public class TestCaseValidationServiceTest {
 
   @Test
   public void testValidateTestCaseJsonHandlesGoodResponse() {
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(hapiValidOutcome);
 
     HapiOperationOutcome output =
         testCaseValidationService.validateTestCaseJson(
-            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN");
+            TestCase.builder().json("{}").build(), ModelType.QI_CORE, "TOKEN", false);
     assertThat(output, is(notNullValue()));
     assertThat(output.getCode(), is(equalTo(200)));
     assertThat(output.getMessage(), is(nullValue()));
@@ -374,7 +387,7 @@ public class TestCaseValidationServiceTest {
     final String accessToken = "Bearer Token";
     final ModelType model = ModelType.QI_CORE;
     List<TestCase> output =
-        testCaseValidationService.validateTestCasesAsResources(null, model, accessToken);
+        testCaseValidationService.validateTestCasesAsResources(null, accessToken);
     assertThat(output, is(notNullValue()));
     assertThat(output.isEmpty(), is(true));
   }
@@ -384,8 +397,11 @@ public class TestCaseValidationServiceTest {
     final String accessToken = "Bearer Token";
     final ModelType model = ModelType.QI_CORE;
     final List<TestCase> testCases = List.of();
+    final TestCaseConfiguration configuration = TestCaseConfiguration.builder().build();
+    Measure measure =
+        Measure.builder().testCases(testCases).testCaseConfiguration(configuration).build();
     List<TestCase> output =
-        testCaseValidationService.validateTestCasesAsResources(testCases, model, accessToken);
+        testCaseValidationService.validateTestCasesAsResources(measure, accessToken);
     assertThat(output, is(notNullValue()));
     assertThat(output.isEmpty(), is(true));
   }
@@ -399,13 +415,21 @@ public class TestCaseValidationServiceTest {
             .build();
     final String accessToken = "Bearer Token";
 
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenReturn(
             ResponseEntity.ok(HapiOperationOutcome.builder().code(200).successful(true).build()));
-    final ModelType model = ModelType.QI_CORE;
+    final String model = ModelType.QI_CORE.getValue();
     final List<TestCase> testCases = List.of(testCase);
+    final TestCaseConfiguration configuration = TestCaseConfiguration.builder().build();
+    Measure measure =
+        Measure.builder()
+            .model(model)
+            .testCases(testCases)
+            .testCaseConfiguration(configuration)
+            .build();
     List<TestCase> output =
-        testCaseValidationService.validateTestCasesAsResources(testCases, model, accessToken);
+        testCaseValidationService.validateTestCasesAsResources(measure, accessToken);
     assertThat(output, is(notNullValue()));
     assertThat(output.isEmpty(), is(false));
     assertThat(output.get(0), is(notNullValue()));
@@ -468,11 +492,17 @@ public class TestCaseValidationServiceTest {
             anyString(), anyString(), any(UUID.class)))
         .thenReturn(validating);
 
-    when(fhirServicesClient.validateBundle(anyString(), any(ModelType.class), anyString()))
+    when(fhirServicesClient.validateBundle(
+            anyString(), any(ModelType.class), anyString(), anyBoolean()))
         .thenThrow(HttpClientErrorException.class);
 
     spyService.validate(
-        UUID.randomUUID(), measure.getId(), testCase, ModelType.QI_CORE_6_0_0, "Bearer Token");
+        UUID.randomUUID(),
+        measure.getId(),
+        testCase,
+        ModelType.QI_CORE_6_0_0,
+        "Bearer Token",
+        false);
 
     verify(spyService, times(1))
         .validate(
@@ -480,7 +510,8 @@ public class TestCaseValidationServiceTest {
             eq(measure.getId()),
             eq(measure.getTestCases().get(0)),
             eq(ModelType.QI_CORE_6_0_0),
-            anyString());
+            anyString(),
+            false);
   }
 
   @Test
@@ -493,7 +524,7 @@ public class TestCaseValidationServiceTest {
     String accessToken = "token";
     ModelType modelType = ModelType.QI_CORE_6_0_0;
 
-    service.submitOnImportValidationTask(measureId, testCase, accessToken, modelType);
+    service.submitOnImportValidationTask(measureId, testCase, accessToken, modelType, false);
 
     verify(importExecutor, times(1)).submit(any(Runnable.class));
   }
@@ -552,6 +583,7 @@ public class TestCaseValidationServiceTest {
             eq(measureId),
             eq(pendingValidation.getTestCases().get(0)),
             eq(modelType),
-            eq(accessToken));
+            eq(accessToken),
+            eq(false));
   }
 }


### PR DESCRIPTION


## MADiE PR

Jira Ticket: [MAT-9962](https://jira.cms.gov/browse/MAT-9962)
(Optional) Related Tickets:

### Summary
- Allow invalid Patient references in test cases into test case
- Update test case validation based on executeInvalidTestCases configuration
- if executeInvalidTestCases is true, we want to allow invalid references to the Patient resource. however, we still going to display the warnings instead of errors.
-  if executeInvalidTestCases is false, this should function the way it is currently working i.e. showing errors for invalid references irrespective of resource type

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
