### PR TITLE
MAT-10110: version composite measures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.10.0-SNAPSHOT</version>
+      <version>0.10.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>gov.cms.madie</groupId>
       <artifactId>madie-java-models</artifactId>
-      <version>0.10.2-SNAPSHOT</version>
+      <version>0.10.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.cms.madie</groupId>

--- a/src/main/java/cms/gov/madie/measure/dto/CompositeVersionArtifacts.java
+++ b/src/main/java/cms/gov/madie/measure/dto/CompositeVersionArtifacts.java
@@ -1,0 +1,11 @@
+package cms.gov.madie.measure.dto;
+
+import java.util.List;
+
+import gov.cms.madie.models.measure.Export;
+
+/** Composite versioning artifacts: the with-/without-warnings bundles + component HR snapshot. */
+public record CompositeVersionArtifacts(
+    String bundleJson,
+    String bundleJsonWithoutWarnings,
+    List<Export.ComponentHumanReadable> componentHumanReadables) {}

--- a/src/main/java/cms/gov/madie/measure/services/BundleService.java
+++ b/src/main/java/cms/gov/madie/measure/services/BundleService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import cms.gov.madie.measure.dto.CompositeVersionArtifacts;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
@@ -336,10 +337,4 @@ public class BundleService {
 
   /** The merged composite bundle plus the component exports it was assembled from. */
   private record CompositeBundleResult(String bundleJson, List<Export> componentExports) {}
-
-  /** Composite versioning artifacts: the with-/without-warnings bundles + component HR snapshot. */
-  public record CompositeVersionArtifacts(
-      String bundleJson,
-      String bundleJsonWithoutWarnings,
-      List<Export.ComponentHumanReadable> componentHumanReadables) {}
 }

--- a/src/main/java/cms/gov/madie/measure/services/BundleService.java
+++ b/src/main/java/cms/gov/madie/measure/services/BundleService.java
@@ -2,7 +2,9 @@ package cms.gov.madie.measure.services;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -137,22 +139,7 @@ public class BundleService {
 
   private String bundleCompositeMeasure(
       Measure measure, String accessToken, String bundleType, String elmErrorSeverity) {
-    try {
-      populateComponentDetails(measure);
-      String compositeBundle =
-          fhirServicesClient.getMeasureBundle(measure, accessToken, bundleType, elmErrorSeverity);
-      List<Export> componentExports = getComponentExports(measure, elmErrorSeverity);
-      PackagingUtility utility = getPackagingUtility(measure.getModel());
-      return utility.buildCompositeMeasureBundle(compositeBundle, componentExports);
-    } catch (RestClientException
-        | InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException
-        | NoSuchMethodException
-        | ClassNotFoundException ex) {
-      log.error("An error occurred while bundling composite measure {}", measure.getId(), ex);
-      throw new BundleOperationException("Measure", measure.getId(), ex);
-    }
+    return generateCompositeBundle(measure, accessToken, bundleType, elmErrorSeverity).bundleJson();
   }
 
   private String bundleStandardMeasure(
@@ -182,6 +169,68 @@ public class BundleService {
     log.error(
         "Bundle with warnings is not available for versioned measure with id: {}", measure.getId());
     throw new BundleOperationException("Measure", measure.getId(), null);
+  }
+
+  /**
+   * Builds the artifacts persisted when versioning a composite: the merged composite bundle both
+   * with ELM warnings ("Info" severity) and without ("Error" severity) and a snapshot of each
+   * component's human-readable.
+   */
+  CompositeVersionArtifacts buildCompositeVersionArtifacts(Measure measure, String accessToken) {
+    CompositeBundleResult withWarnings =
+        generateCompositeBundle(measure, accessToken, "export", "Info");
+    CompositeBundleResult withoutWarnings =
+        generateCompositeBundle(measure, accessToken, "export", "Error");
+    List<Export.ComponentHumanReadable> componentHumanReadables =
+        buildComponentHumanReadables(withWarnings.componentExports());
+    return new CompositeVersionArtifacts(
+        withWarnings.bundleJson(), withoutWarnings.bundleJson(), componentHumanReadables);
+  }
+
+  private CompositeBundleResult generateCompositeBundle(
+      Measure measure, String accessToken, String bundleType, String elmErrorSeverity) {
+    try {
+      populateComponentDetails(measure);
+      String compositeBundle =
+          fhirServicesClient.getMeasureBundle(measure, accessToken, bundleType, elmErrorSeverity);
+      List<Export> componentExports = getComponentExports(measure, elmErrorSeverity);
+      PackagingUtility utility = getPackagingUtility(measure.getModel());
+      String bundleJson = utility.buildCompositeMeasureBundle(compositeBundle, componentExports);
+      return new CompositeBundleResult(bundleJson, componentExports);
+    } catch (RestClientException
+        | InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException
+        | ClassNotFoundException ex) {
+      log.error("An error occurred while bundling composite measure {}", measure.getId(), ex);
+      throw new BundleOperationException("Measure", measure.getId(), ex);
+    }
+  }
+
+  /** Snapshots each component's stored human-readable */
+  private List<Export.ComponentHumanReadable> buildComponentHumanReadables(
+      List<Export> componentExports) {
+    List<Export.ComponentHumanReadable> componentHumanReadables = new ArrayList<>();
+    if (CollectionUtils.isEmpty(componentExports)) {
+      return componentHumanReadables;
+    }
+    Map<String, Measure> measuresById = new HashMap<>();
+    measureRepository
+        .findAllById(componentExports.stream().map(Export::getMeasureId).toList())
+        .forEach(componentMeasure -> measuresById.put(componentMeasure.getId(), componentMeasure));
+    for (Export componentExport : componentExports) {
+      Measure componentMeasure = measuresById.get(componentExport.getMeasureId());
+      if (componentMeasure != null) {
+        componentHumanReadables.add(
+            Export.ComponentHumanReadable.builder()
+                .componentId(componentExport.getMeasureId())
+                .fileName(ExportFileNamesUtil.getExportFileName(componentMeasure))
+                .humanReadable(componentExport.getHumanReadable())
+                .build());
+      }
+    }
+    return componentHumanReadables;
   }
 
   private Export fetchExportForMeasure(String measureId, String elmErrorSeverity) {
@@ -284,4 +333,13 @@ public class BundleService {
           ClassNotFoundException {
     return PackagingUtilityFactory.getInstance(model);
   }
+
+  /** The merged composite bundle plus the component exports it was assembled from. */
+  private record CompositeBundleResult(String bundleJson, List<Export> componentExports) {}
+
+  /** Composite versioning artifacts: the with-/without-warnings bundles + component HR snapshot. */
+  public record CompositeVersionArtifacts(
+      String bundleJson,
+      String bundleJsonWithoutWarnings,
+      List<Export.ComponentHumanReadable> componentHumanReadables) {}
 }

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.CompositeVersionArtifacts;
 import cms.gov.madie.measure.dto.MadieFeatureFlag;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.*;
@@ -142,7 +143,7 @@ public class VersionService {
     Measure upversionedMeasure = version(versionType, username, measure);
 
     if (upversionedMeasure.getMeasureMetaData().isComposite()) {
-      BundleService.CompositeVersionArtifacts compositeVersionArtifacts =
+      CompositeVersionArtifacts compositeVersionArtifacts =
           bundleService.buildCompositeVersionArtifacts(upversionedMeasure, accessToken);
 
       saveMeasureBundle(

--- a/src/main/java/cms/gov/madie/measure/services/VersionService.java
+++ b/src/main/java/cms/gov/madie/measure/services/VersionService.java
@@ -50,6 +50,7 @@ public class VersionService {
   private final AppConfigService appConfigService;
   private final TestCaseValidationService testCaseValidationService;
   private final MeasureLockService measureLockService;
+  private final BundleService bundleService;
 
   public enum VersionValidationResult {
     VALID,
@@ -140,6 +141,20 @@ public class VersionService {
       String versionType, String username, String accessToken, Measure measure) {
     Measure upversionedMeasure = version(versionType, username, measure);
 
+    if (upversionedMeasure.getMeasureMetaData().isComposite()) {
+      BundleService.CompositeVersionArtifacts compositeVersionArtifacts =
+          bundleService.buildCompositeVersionArtifacts(upversionedMeasure, accessToken);
+
+      saveMeasureBundle(
+          upversionedMeasure,
+          compositeVersionArtifacts.bundleJson(),
+          compositeVersionArtifacts.bundleJsonWithoutWarnings(),
+          compositeVersionArtifacts.componentHumanReadables(),
+          username);
+
+      return applyMeasureVersion(versionType, username, upversionedMeasure);
+    }
+
     // Generate Bundle for versioned Measure with ELM at error severity Info
     elmToJsonService.retrieveElmJson(measure, "Info", accessToken);
     var measureBundle =
@@ -150,7 +165,8 @@ public class VersionService {
     var measureBundleWithoutWarnings =
         fhirServicesClient.getMeasureBundle(upversionedMeasure, accessToken, "export", "Error");
 
-    saveMeasureBundle(upversionedMeasure, measureBundle, measureBundleWithoutWarnings, username);
+    saveMeasureBundle(
+        upversionedMeasure, measureBundle, measureBundleWithoutWarnings, null, username);
     return applyMeasureVersion(versionType, username, upversionedMeasure);
   }
 
@@ -171,13 +187,18 @@ public class VersionService {
           .getTestCases()
           .forEach(testCase -> testCase.setCreatedBeforeVersioning(true));
     }
-    String newCql =
-        upversionedMeasure
-            .getCql()
-            .replace(
-                generateLibraryContentLine(upversionedMeasure.getCqlLibraryName(), oldVersion),
-                generateLibraryContentLine(upversionedMeasure.getCqlLibraryName(), newVersion));
-    upversionedMeasure.setCql(newCql);
+
+    // Composite measures have no CQL; only rewrite the library version line when CQL exists.
+    if (StringUtils.isNotBlank(upversionedMeasure.getCql())) {
+      String newCql =
+          upversionedMeasure
+              .getCql()
+              .replace(
+                  generateLibraryContentLine(upversionedMeasure.getCqlLibraryName(), oldVersion),
+                  generateLibraryContentLine(upversionedMeasure.getCqlLibraryName(), newVersion));
+      upversionedMeasure.setCql(newCql);
+    }
+
     return upversionedMeasure;
   }
 
@@ -448,22 +469,10 @@ public class VersionService {
       throw new BadVersionRequestException(
           "Measure", measure.getId(), username, "Measure is not in a draft state.");
     }
-    if (measure.isCqlErrors()) {
-      log.error(
-          "User [{}] attempted to version measure with id [{}] which has CQL errors",
-          username,
-          measure.getId());
-      throw new BadVersionRequestException(
-          "Measure", measure.getId(), username, "Measure has CQL errors.");
-    }
-    if (StringUtils.isBlank(measure.getCql())) {
-      log.error(
-          "User [{}] attempted to version measure with id [{}] which has empty CQL",
-          username,
-          measure.getId());
-      throw new BadVersionRequestException(
-          "Measure", measure.getId(), username, "Measure has no CQL.");
-    }
+
+    boolean isComposite =
+        measure.getMeasureMetaData() != null && measure.getMeasureMetaData().isComposite();
+
     if (CollectionUtils.isEmpty(measure.getGroups())) {
       log.error(
           "User [{}] attempted to version measure with id [{}] which does not have at least "
@@ -477,10 +486,29 @@ public class VersionService {
           "Measure does not have at least one Population Criteria.");
     }
 
-    final ElmJson elmJson =
-        elmTranslatorClient.getElmJson(measure.getCql(), measure.getModel(), accessToken);
-    if (elmTranslatorClient.hasErrors(elmJson)) {
-      throw new CqlElmTranslationErrorException(measure.getMeasureName());
+    if (!isComposite) {
+      if (measure.isCqlErrors()) {
+        log.error(
+            "User [{}] attempted to version measure with id [{}] which has CQL errors",
+            username,
+            measure.getId());
+        throw new BadVersionRequestException(
+            "Measure", measure.getId(), username, "Measure has CQL errors.");
+      }
+      if (StringUtils.isBlank(measure.getCql())) {
+        log.error(
+            "User [{}] attempted to version measure with id [{}] which has empty CQL",
+            username,
+            measure.getId());
+        throw new BadVersionRequestException(
+            "Measure", measure.getId(), username, "Measure has no CQL.");
+      }
+
+      final ElmJson elmJson =
+          elmTranslatorClient.getElmJson(measure.getCql(), measure.getModel(), accessToken);
+      if (elmTranslatorClient.hasErrors(elmJson)) {
+        throw new CqlElmTranslationErrorException(measure.getMeasureName());
+      }
     }
   }
 
@@ -524,7 +552,8 @@ public class VersionService {
       Measure savedMeasure,
       String measureBundle,
       String measureBundleWithoutWarnings,
-      String humanReadableWithCss) {
+      String humanReadableWithCss,
+      List<Export.ComponentHumanReadable> componentHumanReadables) {
     ObjectId measureBundleId =
         mongoGridFsService.save(
             new ByteArrayInputStream(measureBundle.getBytes()),
@@ -544,6 +573,7 @@ public class VersionService {
             .measureBundleGridFsId(measureBundleId.toHexString())
             .measureBundleWithoutWarningsGridFsId(measureBundleWithoutWarningsId.toHexString())
             .humanReadable(humanReadableWithCss)
+            .componentHumanReadables(componentHumanReadables)
             .build();
 
     return exportRepository.save(export);
@@ -553,6 +583,7 @@ public class VersionService {
       Measure savedMeasure,
       String measureBundle,
       String measureBundleWithoutWarnings,
+      List<Export.ComponentHumanReadable> componentHumanReadables,
       String username) {
     String humanReadableWithCss;
     try {
@@ -567,7 +598,12 @@ public class VersionService {
     }
 
     Export savedExport =
-        saveExport(savedMeasure, measureBundle, measureBundleWithoutWarnings, humanReadableWithCss);
+        saveExport(
+            savedMeasure,
+            measureBundle,
+            measureBundleWithoutWarnings,
+            humanReadableWithCss,
+            componentHumanReadables);
     log.info(
         "User [{}] successfully saved versioned measure's export data with ID [{}]",
         username,

--- a/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.CompositeVersionArtifacts;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.BundleOperationException;
 import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
@@ -255,7 +256,7 @@ class BundleServiceTest implements ResourceUtil {
     when(mongoGridFsService.findById("comp-grid-fs-id")).thenReturn(bundle);
     when(mongoGridFsService.findById("comp-grid-fs-id-nw")).thenReturn(bundle);
 
-    BundleService.CompositeVersionArtifacts artifacts =
+    CompositeVersionArtifacts artifacts =
         bundleService.buildCompositeVersionArtifacts(measure, "Bearer TOKEN");
 
     assertNotNull(artifacts);

--- a/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/BundleServiceTest.java
@@ -202,6 +202,76 @@ class BundleServiceTest implements ResourceUtil {
   }
 
   @Test
+  void testBuildCompositeVersionArtifactsSnapshotsComponentHumanReadables() {
+    Measure componentMeasure =
+        Measure.builder()
+            .id("comp-measure-id")
+            .measureName("ComponentMeasure")
+            .ecqmTitle("ComponentMeasure")
+            .cqlLibraryName("ComponentLib")
+            .version(new Version(1, 0, 0))
+            .model("QI-Core v4.1.1")
+            .measureMetaData(MeasureMetaData.builder().draft(false).build())
+            .groups(List.of(Group.builder().id("comp-group-1").displayId("Group 1").build()))
+            .build();
+
+    Component component =
+        Component.builder().measureId("comp-measure-id").groupId("comp-group-1").build();
+    Group compositeGroup =
+        Group.builder()
+            .id("composite-group-1")
+            .components(List.of(component))
+            .populationBasis("boolean")
+            .measureGroupTypes(List.of(MeasureGroupTypes.PROCESS))
+            .build();
+
+    measure.setGroups(List.of(compositeGroup));
+    measure.setModel("QI-Core v4.1.1");
+    measure.setMeasureMetaData(
+        MeasureMetaData.builder()
+            .draft(true)
+            .composite(true)
+            .steward(Organization.builder().name("SemanticBits").build())
+            .description("Composite measure")
+            .developers(List.of(Organization.builder().name("ICF").build()))
+            .build());
+
+    final String bundle = gov.cms.madie.packaging.utils.JsonBits.BUNDLE;
+    when(measureRepository.findById("comp-measure-id")).thenReturn(Optional.of(componentMeasure));
+    when(measureRepository.findAllById(any())).thenReturn(List.of(componentMeasure));
+    when(fhirServicesClient.getMeasureBundle(
+            any(Measure.class), anyString(), eq("export"), anyString()))
+        .thenReturn(bundle);
+
+    Export componentExport =
+        Export.builder()
+            .measureId("comp-measure-id")
+            .measureBundleGridFsId("comp-grid-fs-id")
+            .measureBundleWithoutWarningsGridFsId("comp-grid-fs-id-nw")
+            .humanReadable("<html>component HR</html>")
+            .build();
+    when(exportRepository.findByMeasureId("comp-measure-id"))
+        .thenReturn(Optional.of(componentExport));
+    when(mongoGridFsService.findById("comp-grid-fs-id")).thenReturn(bundle);
+    when(mongoGridFsService.findById("comp-grid-fs-id-nw")).thenReturn(bundle);
+
+    BundleService.CompositeVersionArtifacts artifacts =
+        bundleService.buildCompositeVersionArtifacts(measure, "Bearer TOKEN");
+
+    assertNotNull(artifacts);
+    assertNotNull(artifacts.bundleJson());
+    assertNotNull(artifacts.bundleJsonWithoutWarnings());
+    assertEquals(
+        List.of(
+            Export.ComponentHumanReadable.builder()
+                .componentId("comp-measure-id")
+                .fileName("ComponentMeasure-v1.0.000-FHIR")
+                .humanReadable("<html>component HR</html>")
+                .build()),
+        artifacts.componentHumanReadables());
+  }
+
+  @Test
   void testBundleMeasureReturnsBundleStringForVersionedMeasure() {
     final String json = "{\"message\": \"GOOD JSON\"}";
     Export export = Export.builder().measureId(measure.getId()).measureBundleJson(json).build();

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -325,6 +325,7 @@ public class VersionServiceTest {
             .id("testMeasureId")
             .createdBy("testUser")
             .cqlErrors(true)
+            .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
             .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
@@ -333,26 +334,36 @@ public class VersionServiceTest {
 
     when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
-    assertThrows(
-        BadVersionRequestException.class,
-        () -> versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    Exception ex =
+        assertThrows(
+            BadVersionRequestException.class,
+            () ->
+                versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    assertTrue(ex.getMessage().contains("Measure has CQL errors."));
   }
 
   @Test
   public void testCheckValidVersioningThrowsBadVersionRequestExceptionForCqlErrors() {
     Measure existingMeasure =
-        Measure.builder().id("testMeasureId").createdBy("testUser").cqlErrors(true).build();
+        Measure.builder()
+            .id("testMeasureId")
+            .createdBy("testUser")
+            .cqlErrors(true)
+            .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
+            .build();
     MeasureMetaData metaData = new MeasureMetaData();
     metaData.setDraft(true);
     existingMeasure.setMeasureMetaData(metaData);
 
     when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
-    assertThrows(
-        BadVersionRequestException.class,
-        () ->
-            versionService.checkValidVersioning(
-                "testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    Exception ex =
+        assertThrows(
+            BadVersionRequestException.class,
+            () ->
+                versionService.checkValidVersioning(
+                    "testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    assertTrue(ex.getMessage().contains("Measure has CQL errors."));
   }
 
   @Test
@@ -363,6 +374,7 @@ public class VersionServiceTest {
             .createdBy("testUser")
             .cqlErrors(false)
             .cql("")
+            .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
             .measureSet(measureSet)
             .build();
     MeasureMetaData metaData = new MeasureMetaData();
@@ -371,9 +383,12 @@ public class VersionServiceTest {
 
     when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
 
-    assertThrows(
-        BadVersionRequestException.class,
-        () -> versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    Exception ex =
+        assertThrows(
+            BadVersionRequestException.class,
+            () ->
+                versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    assertTrue(ex.getMessage().contains("Measure has no CQL."));
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -73,6 +73,8 @@ public class VersionServiceTest {
 
   @Mock private MeasureLockService measureLockService;
 
+  @Mock private BundleService bundleService;
+
   @Captor private ArgumentCaptor<Measure> measureCaptor;
   @Captor private ArgumentCaptor<CqmMeasure> cqmMeasureCaptor;
   @Captor private ArgumentCaptor<Export> exportArgumentCaptor;
@@ -665,6 +667,119 @@ public class VersionServiceTest {
     assertEquals(savedValue.getId(), capturedExport.getMeasureId());
     assertEquals("hex1", capturedExport.getMeasureBundleGridFsId());
     assertEquals("hex2", capturedExport.getMeasureBundleWithoutWarningsGridFsId());
+  }
+
+  @Test
+  public void testCreateVersionCompositeMeasureSuccessWithNoCql() {
+    FhirMeasure existingMeasure =
+        FhirMeasure.builder()
+            .id("testMeasureId")
+            .measureSetId("testMeasureSetId")
+            .createdBy("testUser")
+            .cql(null)
+            .groups(List.of(cvGroup.toBuilder().id(ObjectId.get().toString()).build()))
+            .model(ModelType.QI_CORE.getValue())
+            .measureSet(measureSet)
+            .build();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    metaData.setComposite(true);
+    existingMeasure.setMeasureMetaData(metaData);
+    existingMeasure.setVersion(Version.builder().major(2).minor(3).revisionNumber(1).build());
+
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
+    when(measureRepository.findMaxVersionByMeasureSetId(anyString()))
+        .thenReturn(Optional.of(Version.builder().major(2).minor(3).revisionNumber(1).build()));
+
+    Measure updatedMeasure = existingMeasure.toBuilder().build();
+    updatedMeasure.setVersion(Version.builder().major(3).minor(0).revisionNumber(0).build());
+    MeasureMetaData updatedMetaData = new MeasureMetaData();
+    updatedMetaData.setDraft(false);
+    updatedMetaData.setComposite(true);
+    updatedMeasure.setMeasureMetaData(updatedMetaData);
+    when(measureRepository.save(any(Measure.class))).thenReturn(updatedMeasure);
+
+    factory.when(() -> PackagingUtilityFactory.getInstance(MODEL_QI_CORE)).thenReturn(utility);
+
+    String compositeBundleJson =
+        """
+            {"resourceType": "Bundle","entry": [ {
+                "resource": {
+                  "resourceType": "Measure","text":{"div":"humanReadable"}}}]}""";
+    List<Export.ComponentHumanReadable> componentHumanReadables =
+        List.of(
+            Export.ComponentHumanReadable.builder()
+                .componentId("component-measure-id")
+                .fileName("ComponentMeasure-v1.0.000-FHIR")
+                .humanReadable("<html>component human readable</html>")
+                .build());
+    when(bundleService.buildCompositeVersionArtifacts(any(Measure.class), anyString()))
+        .thenReturn(
+            new BundleService.CompositeVersionArtifacts(
+                compositeBundleJson, compositeBundleJson, componentHumanReadables));
+
+    Export measureExport =
+        Export.builder()
+            .id("testId")
+            .measureId("testMeasureId")
+            .measureBundleJson(compositeBundleJson)
+            .build();
+    when(exportRepository.save(any(Export.class))).thenReturn(measureExport);
+
+    ObjectId measureBundleId = mock(ObjectId.class);
+    when(measureBundleId.toHexString()).thenReturn("hex1");
+    ObjectId measureBundleWithoutWarningsId = mock(ObjectId.class);
+    when(measureBundleWithoutWarningsId.toHexString()).thenReturn("hex2");
+    when(mongoGridFsService.save(any(ByteArrayInputStream.class), anyString(), anyString()))
+        .thenReturn(measureBundleId, measureBundleWithoutWarningsId);
+
+    versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken");
+
+    verify(bundleService, times(1)).buildCompositeVersionArtifacts(any(Measure.class), anyString());
+    // composites skip CQL/ELM validation
+    verify(elmTranslatorClient, never()).getElmJson(anyString(), anyString(), anyString());
+    verify(elmToJsonService, never()).retrieveElmJson(any(Measure.class), anyString(), anyString());
+
+    verify(measureRepository, times(1)).save(measureCaptor.capture());
+    Measure savedValue = measureCaptor.getValue();
+    assertEquals(3, savedValue.getVersion().getMajor());
+    assertFalse(savedValue.getMeasureMetaData().isDraft());
+
+    verify(exportRepository, times(1)).save(exportArgumentCaptor.capture());
+    Export capturedExport = exportArgumentCaptor.getValue();
+    assertEquals(savedValue.getId(), capturedExport.getMeasureId());
+    assertEquals("hex1", capturedExport.getMeasureBundleGridFsId());
+    assertEquals("hex2", capturedExport.getMeasureBundleWithoutWarningsGridFsId());
+    assertEquals(componentHumanReadables, capturedExport.getComponentHumanReadables());
+  }
+
+  @Test
+  public void testCreateVersionCompositeMeasureFailsWithNoPopulationCriteria() {
+    FhirMeasure existingMeasure =
+        FhirMeasure.builder()
+            .id("testMeasureId")
+            .measureSetId("testMeasureSetId")
+            .createdBy("testUser")
+            .cql(null)
+            .groups(List.of())
+            .model(ModelType.QI_CORE.getValue())
+            .measureSet(measureSet)
+            .build();
+    MeasureMetaData metaData = new MeasureMetaData();
+    metaData.setDraft(true);
+    metaData.setComposite(true);
+    existingMeasure.setMeasureMetaData(metaData);
+    existingMeasure.setVersion(Version.builder().major(1).minor(0).revisionNumber(0).build());
+
+    when(measureService.findMeasureById(anyString())).thenReturn(existingMeasure);
+
+    BadVersionRequestException ex =
+        assertThrows(
+            BadVersionRequestException.class,
+            () ->
+                versionService.createVersion("testMeasureId", "MAJOR", "testUser", "accesstoken"));
+    assertTrue(ex.getMessage().contains("Population Criteria"));
+    verify(bundleService, never()).buildCompositeVersionArtifacts(any(Measure.class), anyString());
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/VersionServiceTest.java
@@ -1,5 +1,6 @@
 package cms.gov.madie.measure.services;
 
+import cms.gov.madie.measure.dto.CompositeVersionArtifacts;
 import cms.gov.madie.measure.dto.MadieFeatureFlag;
 import cms.gov.madie.measure.dto.PackageDto;
 import cms.gov.madie.measure.exceptions.BadVersionRequestException;
@@ -730,7 +731,7 @@ public class VersionServiceTest {
                 .build());
     when(bundleService.buildCompositeVersionArtifacts(any(Measure.class), anyString()))
         .thenReturn(
-            new BundleService.CompositeVersionArtifacts(
+            new CompositeVersionArtifacts(
                 compositeBundleJson, compositeBundleJson, componentHumanReadables));
 
     Export measureExport =


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-10110](https://jira.cms.gov/browse/MAT-10110)
(Optional) Related Tickets:

### Summary

- Relax versioning validations for composite measures (skip CQL/ELM checks, still require a Population Criteria, don't check populations)
- On versioning of a composite measure, generate the merged composite bundle with and without ELM warnings and persist the composite bundle in the DB. In addition, snapshot each component measure's human-readable on the Export collection

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
