### PR TITLE
MAT-9811: allow admin draft delete and clean up composite relationships on permanent delete

### DIFF
--- a/src/main/java/cms/gov/madie/measure/resources/AdminController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/AdminController.java
@@ -72,6 +72,7 @@ public class AdminController extends AbstractMeasureController {
   private final AdminService adminService;
   private final AppConfigService appConfigService;
   private final CacheManager cacheManager;
+  private final CompositeRelationshipService compositeRelationshipService;
 
   @Override
   protected AppConfigService getAppConfigService() {
@@ -310,6 +311,8 @@ public class AdminController extends AbstractMeasureController {
             harpId, measureToDelete.getMeasureSet().getOwner(), measureToDelete.getId());
       }
 
+      compositeRelationshipService.removeCompositeRelationships(
+          measureToDelete, principal.getName().toLowerCase());
       measureRepository.delete(measureToDelete);
       actionLogService.logAction(
           id, Measure.class, ActionType.DELETED, principal.getName().toLowerCase());

--- a/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
+++ b/src/main/java/cms/gov/madie/measure/resources/MeasureController.java
@@ -239,10 +239,12 @@ public class MeasureController extends AbstractMeasureController {
 
   @DeleteMapping("/measures/{id}/delete")
   public ResponseEntity<Measure> deactivateMeasure(
-      @PathVariable("id") String id, Principal principal) {
+      @PathVariable("id") String id,
+      Principal principal,
+      @RequestHeader("Authorization") String accessToken) {
 
     return ResponseEntity.ok()
-        .body(measureService.deactivateMeasure(id, principal.getName().toLowerCase()));
+        .body(measureService.deactivateMeasure(id, principal.getName().toLowerCase(), accessToken));
   }
 
   @GetMapping("/measures/shared")

--- a/src/main/java/cms/gov/madie/measure/services/CompositeRelationshipService.java
+++ b/src/main/java/cms/gov/madie/measure/services/CompositeRelationshipService.java
@@ -5,8 +5,10 @@ import cms.gov.madie.measure.repositories.MeasureRepository;
 import gov.cms.madie.models.common.ActionType;
 import gov.cms.madie.models.measure.Component;
 import gov.cms.madie.models.measure.Measure;
+import gov.cms.madie.models.measure.MeasureScoring;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -117,5 +119,26 @@ public class CompositeRelationshipService {
               username,
               "Removed from Composite measure " + compositeName);
         });
+  }
+
+  /**
+   * Removes {@code compositeMeasure} from the {@code compositeMeasureIds} of each of its component
+   * measures. Used when a composite measure is deleted so its components are not left referencing a
+   * composite that no longer exists.
+   */
+  public void removeCompositeRelationships(Measure compositeMeasure, String username) {
+    if (compositeMeasure.getMeasureMetaData() != null
+        && compositeMeasure.getMeasureMetaData().isComposite()
+        && !CollectionUtils.isEmpty(compositeMeasure.getGroups())) {
+      List<Component> allComponents =
+          compositeMeasure.getGroups().stream()
+              .filter(g -> MeasureScoring.COMPOSITE.toString().equalsIgnoreCase(g.getScoring()))
+              .filter(g -> !CollectionUtils.isEmpty(g.getComponents()))
+              .flatMap(g -> g.getComponents().stream())
+              .toList();
+      if (!allComponents.isEmpty()) {
+        syncComponents(allComponents, List.of(), compositeMeasure, username);
+      }
+    }
   }
 }

--- a/src/main/java/cms/gov/madie/measure/services/MeasureService.java
+++ b/src/main/java/cms/gov/madie/measure/services/MeasureService.java
@@ -350,7 +350,8 @@ public class MeasureService extends BaseMeasureService {
     }
   }
 
-  public Measure deactivateMeasure(final String id, final String username) {
+  public Measure deactivateMeasure(
+      final String id, final String username, final String accessToken) {
     if (StringUtils.isBlank(id) || StringUtils.isBlank(username)) {
       throw new InvalidIdException("Username and Measure Id is required.");
     }
@@ -358,7 +359,10 @@ public class MeasureService extends BaseMeasureService {
     if (existingMeasure == null) {
       throw new ResourceNotFoundException("Measure does not exist.");
     }
-    if (!username.equalsIgnoreCase(existingMeasure.getMeasureSet().getOwner())) {
+    // Owners of a draft measure or Admins can delete the draft measure
+    boolean isAdmin = userServiceClient.hasRole(username, RoleConstants.MADiE_ADMIN, accessToken);
+
+    if (!isAdmin && !username.equalsIgnoreCase(existingMeasure.getMeasureSet().getOwner())) {
       throw new UnauthorizedException("User is not authorized to delete this measure.");
     }
 
@@ -382,19 +386,7 @@ public class MeasureService extends BaseMeasureService {
     existingMeasure.setMeasureSetId(existingMeasure.getMeasureSetId());
     Measure saveMeasure = measureRepository.save(existingMeasure);
 
-    if (existingMeasure.getMeasureMetaData().isComposite()
-        && !CollectionUtils.isEmpty(existingMeasure.getGroups())) {
-      List<Component> allComponents =
-          existingMeasure.getGroups().stream()
-              .filter(g -> MeasureScoring.COMPOSITE.toString().equalsIgnoreCase(g.getScoring()))
-              .filter(g -> !CollectionUtils.isEmpty(g.getComponents()))
-              .flatMap(g -> g.getComponents().stream())
-              .toList();
-      if (!allComponents.isEmpty()) {
-        compositeRelationshipService.syncComponents(
-            allComponents, List.of(), existingMeasure, username);
-      }
-    }
+    compositeRelationshipService.removeCompositeRelationships(existingMeasure, username);
 
     actionLogService.logAction(id, Measure.class, ActionType.DELETED, username);
     measureLockService.unlockMeasure(id, username);

--- a/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/AdminControllerMvcTest.java
@@ -100,6 +100,7 @@ public class AdminControllerMvcTest {
   @MockitoBean private AppConfigService appConfigService;
   @MockitoBean private UserServiceClient userServiceClient;
   @MockitoBean private CacheManager cacheManager;
+  @MockitoBean private CompositeRelationshipService compositeRelationshipService;
 
   @Autowired private MockMvc mockMvc;
 
@@ -532,6 +533,38 @@ public class AdminControllerMvcTest {
                 .header("harpId", "owner1"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id", equalTo("12345")));
+
+    verify(compositeRelationshipService, times(1))
+        .removeCompositeRelationships(eq(testMsr), anyString());
+  }
+
+  @Test
+  public void testAdminMeasurePermaDeleteCompositeCleansUpComponentRelationships()
+      throws Exception {
+    Measure composite =
+        Measure.builder()
+            .id("12345")
+            .measureSet(MeasureSet.builder().owner("owner1").build())
+            .measureMetaData(MeasureMetaData.builder().composite(true).build())
+            .build();
+    when(measureService.findMeasureById(anyString())).thenReturn(composite);
+    doNothing().when(measureRepository).delete(any(Measure.class));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.delete("/admin/measures/{id}", "12345")
+                .with(csrf())
+                .with(
+                    jwt()
+                        .jwt(jwt -> jwt.claim("sub", TEST_USER_ID))
+                        .authorities(createAuthorityList("ROLE_MADIE-ADMIN")))
+                .header("Authorization", "test-okta")
+                .header("harpId", "owner1"))
+        .andExpect(status().isOk());
+
+    verify(compositeRelationshipService, times(1))
+        .removeCompositeRelationships(eq(composite), anyString());
+    verify(measureRepository, times(1)).delete(composite);
   }
 
   @Test

--- a/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
+++ b/src/test/java/cms/gov/madie/measure/resources/MeasureControllerMvcTest.java
@@ -2317,7 +2317,7 @@ public class MeasureControllerMvcTest {
   public void testDeactivateMeasureSuccessfully() throws Exception {
     String measureId = "f225481c-921e-4015-9e14-e5046bfac9ff";
 
-    when(measureService.deactivateMeasure(eq(measureId), eq(TEST_USER_ID)))
+    when(measureService.deactivateMeasure(eq(measureId), eq(TEST_USER_ID), eq(ACCESS_TOKEN)))
         .thenReturn(Measure.builder().active(false).id(measureId).build());
     MvcResult result =
         mockMvc
@@ -2332,7 +2332,8 @@ public class MeasureControllerMvcTest {
             .andExpect(status().isOk())
             .andReturn();
 
-    verify(measureService, times(1)).deactivateMeasure(eq(measureId), eq(TEST_USER_ID));
+    verify(measureService, times(1))
+        .deactivateMeasure(eq(measureId), eq(TEST_USER_ID), eq(ACCESS_TOKEN));
     assertThat(result.getResponse().getContentAsString(), containsString("\"active\":false"));
   }
 
@@ -2342,7 +2343,7 @@ public class MeasureControllerMvcTest {
     String reason = "Lock can't be obtained to deactivate";
     doThrow(new LockNotObtainedException(reason))
         .when(measureService)
-        .deactivateMeasure(eq(measureId), eq(TEST_USER_ID));
+        .deactivateMeasure(eq(measureId), eq(TEST_USER_ID), eq("test-okta"));
     MvcResult result =
         mockMvc
             .perform(
@@ -2356,7 +2357,8 @@ public class MeasureControllerMvcTest {
             .andExpect(status().isLocked())
             .andReturn();
 
-    verify(measureService, times(1)).deactivateMeasure(eq(measureId), eq(TEST_USER_ID));
+    verify(measureService, times(1))
+        .deactivateMeasure(eq(measureId), eq(TEST_USER_ID), eq("test-okta"));
     assertThat(result.getResponse().getContentAsString(), containsString(reason));
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/CompositeRelationshipServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/CompositeRelationshipServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -16,8 +17,10 @@ import cms.gov.madie.measure.exceptions.ResourceNotFoundException;
 import cms.gov.madie.measure.repositories.MeasureRepository;
 import gov.cms.madie.models.common.ActionType;
 import gov.cms.madie.models.measure.Component;
+import gov.cms.madie.models.measure.Group;
 import gov.cms.madie.models.measure.Measure;
 import gov.cms.madie.models.measure.MeasureMetaData;
+import gov.cms.madie.models.measure.MeasureScoring;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -234,5 +237,75 @@ public class CompositeRelationshipServiceTest {
             eq(ActionType.REMOVED_FROM_COMPOSITE),
             eq("test.user"),
             eq("Removed from Composite measure Composite Measure"));
+  }
+
+  @Test
+  void testRemoveCompositeRelationshipsDetachesComponents() {
+    String componentMeasureId = "component-measure-id";
+    Measure componentMeasure =
+        Measure.builder()
+            .id(componentMeasureId)
+            .measureName("Component Measure")
+            .compositeMeasureIds(new ArrayList<>(List.of("composite-measure-id")))
+            .build();
+
+    Group compositeGroup =
+        Group.builder()
+            .id("composite-group-id")
+            .scoring(MeasureScoring.COMPOSITE.toString())
+            .components(List.of(Component.builder().measureId(componentMeasureId).build()))
+            .build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureName("Composite Measure")
+            .measureMetaData(MeasureMetaData.builder().draft(false).composite(true).build())
+            .groups(new ArrayList<>(List.of(compositeGroup)))
+            .build();
+
+    when(measureRepository.findAllById(anyCollection())).thenReturn(List.of(componentMeasure));
+
+    compositeRelationshipService.removeCompositeRelationships(compositeMeasure, "test.user");
+
+    verify(measureRepository).saveAll(anyCollection());
+    assertTrue(componentMeasure.getCompositeMeasureIds().isEmpty());
+  }
+
+  @Test
+  void testRemoveCompositeRelationshipsNoOpForNonComposite() {
+    Measure nonComposite =
+        Measure.builder()
+            .id("measure-id")
+            .measureMetaData(MeasureMetaData.builder().draft(false).composite(false).build())
+            .groups(new ArrayList<>())
+            .build();
+
+    compositeRelationshipService.removeCompositeRelationships(nonComposite, "test.user");
+
+    verifyNoInteractions(measureRepository);
+    verifyNoInteractions(actionLogService);
+  }
+
+  @Test
+  void testRemoveCompositeRelationshipsNoOpWhenCompositeHasNoComponents() {
+    Group compositeGroupNoComponents =
+        Group.builder()
+            .id("composite-group-id")
+            .scoring(MeasureScoring.COMPOSITE.toString())
+            .components(new ArrayList<>())
+            .build();
+
+    Measure compositeMeasure =
+        Measure.builder()
+            .id("composite-measure-id")
+            .measureMetaData(MeasureMetaData.builder().draft(false).composite(true).build())
+            .groups(new ArrayList<>(List.of(compositeGroupNoComponents)))
+            .build();
+
+    compositeRelationshipService.removeCompositeRelationships(compositeMeasure, "test.user");
+
+    verifyNoInteractions(measureRepository);
+    verifyNoInteractions(actionLogService);
   }
 }

--- a/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
+++ b/src/test/java/cms/gov/madie/measure/services/MeasureServiceTest.java
@@ -32,6 +32,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import cms.gov.madie.measure.clients.UserServiceClient;
+import cms.gov.madie.measure.config.security.RoleConstants;
 import cms.gov.madie.measure.dto.*;
 import cms.gov.madie.measure.exceptions.*;
 import cms.gov.madie.measure.locks.MeasureLock;
@@ -1280,7 +1281,8 @@ public class MeasureServiceTest implements ResourceUtil {
         .thenReturn(Collections.singletonList(measure));
     // Should not throw because the existing measure belongs to the same measure set
     assertDoesNotThrow(
-        () -> measureService.checkDuplicateCqlLibraryName("testCQLLibraryName", "sameMeasureSetId"));
+        () ->
+            measureService.checkDuplicateCqlLibraryName("testCQLLibraryName", "sameMeasureSetId"));
     verify(measureRepository, times(1)).findAllByCqlLibraryName(eq("testCQLLibraryName"));
   }
 
@@ -2581,7 +2583,8 @@ public class MeasureServiceTest implements ResourceUtil {
     // When & Then
     InvalidIdException exception =
         assertThrows(
-            InvalidIdException.class, () -> measureService.deactivateMeasure(measureId, username));
+            InvalidIdException.class,
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(exception.getMessage(), is(equalTo("Username and Measure Id is required.")));
   }
@@ -2595,7 +2598,8 @@ public class MeasureServiceTest implements ResourceUtil {
     // When & Then
     InvalidIdException exception =
         assertThrows(
-            InvalidIdException.class, () -> measureService.deactivateMeasure(measureId, username));
+            InvalidIdException.class,
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(exception.getMessage(), is(equalTo("Username and Measure Id is required.")));
   }
@@ -2608,7 +2612,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Exception exception =
         assertThrows(
             ResourceNotFoundException.class,
-            () -> measureService.deactivateMeasure(measureId, username));
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(exception.getMessage(), is(equalTo("Measure does not exist.")));
   }
@@ -2632,7 +2636,7 @@ public class MeasureServiceTest implements ResourceUtil {
     UnauthorizedException exception =
         assertThrows(
             UnauthorizedException.class,
-            () -> measureService.deactivateMeasure(measureId, username));
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(
         exception.getMessage(), is(equalTo("User is not authorized to delete this measure.")));
@@ -2660,7 +2664,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Exception exception =
         assertThrows(
             InvalidDraftStatusException.class,
-            () -> measureService.deactivateMeasure(measureId, username));
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(
         exception.getMessage(),
@@ -2689,7 +2693,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Exception exception =
         assertThrows(
             InvalidResourceStateException.class,
-            () -> measureService.deactivateMeasure(measureId, username));
+            () -> measureService.deactivateMeasure(measureId, username, ACCESS_TOKEN));
 
     assertThat(exception.getMessage(), is(equalTo("Measure is inactive.")));
   }
@@ -2720,7 +2724,7 @@ public class MeasureServiceTest implements ResourceUtil {
     Exception exception =
         assertThrows(
             LockNotObtainedException.class,
-            () -> measureService.deactivateMeasure(measureId, currentUser));
+            () -> measureService.deactivateMeasure(measureId, currentUser, ACCESS_TOKEN));
 
     assertThat(
         exception.getMessage(),
@@ -2750,7 +2754,8 @@ public class MeasureServiceTest implements ResourceUtil {
         .thenReturn(true);
 
     // Then
-    Measure result = measureService.deactivateMeasure(existingMeasure.getId(), username);
+    Measure result =
+        measureService.deactivateMeasure(existingMeasure.getId(), username, ACCESS_TOKEN);
 
     assertThat(result, is(notNullValue()));
     assertThat(result.isActive(), is(false));
@@ -2758,6 +2763,38 @@ public class MeasureServiceTest implements ResourceUtil {
     verify(measureRepository).save(measureArgumentCaptor.capture());
     Measure savedMeasure = measureArgumentCaptor.getValue();
     assertThat(savedMeasure.isActive(), is(false));
+  }
+
+  @Test
+  public void testDeactivateMeasureAsAdminWhoIsNotOwner() {
+    // Given: an admin deleting a draft they do not own (MAT-9811)
+    String adminUser = "admin-user";
+    String owner = "some-other-owner";
+
+    Measure existingMeasure =
+        measure1.toBuilder()
+            .active(true)
+            .measureSet(MeasureSet.builder().owner(owner).build())
+            .measureMetaData(draftMeasureMetaData)
+            .build();
+
+    // When
+    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
+    when(userServiceClient.hasRole(adminUser, RoleConstants.MADiE_ADMIN, ACCESS_TOKEN))
+        .thenReturn(true);
+    when(measureLockService.checkMeasureAndTestCaseLock(
+            anyString(), any(Measure.class), anyString()))
+        .thenReturn(false);
+    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
+
+    // Then
+    Measure result =
+        measureService.deactivateMeasure(existingMeasure.getId(), adminUser, ACCESS_TOKEN);
+
+    assertThat(result, is(notNullValue()));
+    assertThat(result.isActive(), is(false));
+    verify(measureRepository).save(measureArgumentCaptor.capture());
+    assertThat(measureArgumentCaptor.getValue().isActive(), is(false));
   }
 
   @Test
@@ -2782,7 +2819,8 @@ public class MeasureServiceTest implements ResourceUtil {
         .thenReturn(LockInfo.builder().build());
 
     // Then
-    Measure result = measureService.deactivateMeasure(existingMeasure.getId(), username);
+    Measure result =
+        measureService.deactivateMeasure(existingMeasure.getId(), username, ACCESS_TOKEN);
 
     assertThat(result, is(notNullValue()));
     assertThat(result.isActive(), is(false));
@@ -2793,7 +2831,7 @@ public class MeasureServiceTest implements ResourceUtil {
   }
 
   @Test
-  public void testDeactivateCompositeMeasureDelegatesToSyncComponents() {
+  public void testDeactivateMeasureDelegatesCompositeCleanup() {
     // Given
     String username = "test-user";
     String componentMeasureId = "component-measure-id";
@@ -2827,106 +2865,9 @@ public class MeasureServiceTest implements ResourceUtil {
         .thenReturn(LockInfo.builder().build());
 
     // Then
-    measureService.deactivateMeasure(existingMeasure.getId(), username);
+    measureService.deactivateMeasure(existingMeasure.getId(), username, ACCESS_TOKEN);
 
-    verify(compositeRelationshipService)
-        .syncComponents(eq(components), eq(List.of()), eq(existingMeasure), eq(username));
-  }
-
-  @Test
-  public void testDeactivateCompositeMeasureWithEmptyGroupsDoesNotDelegate() {
-    // Given
-    String username = "test-user";
-
-    MeasureMetaData compositeMeasureMetaData =
-        draftMeasureMetaData.toBuilder().composite(true).build();
-
-    Measure existingMeasure =
-        measure1.toBuilder()
-            .active(true)
-            .measureSet(MeasureSet.builder().owner(username).build())
-            .measureMetaData(compositeMeasureMetaData)
-            .groups(new ArrayList<>())
-            .build();
-
-    // When
-    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
-    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
-    when(actionLogService.logAction(
-            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
-        .thenReturn(true);
-    when(measureLockService.unlockMeasure(anyString(), anyString()))
-        .thenReturn(LockInfo.builder().build());
-
-    // Then
-    measureService.deactivateMeasure(existingMeasure.getId(), username);
-
-    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
-  }
-
-  @Test
-  public void testDeactivateCompositeMeasureWithNoComponentsDoesNotDelegate() {
-    // Given
-    String username = "test-user";
-
-    Group compositeGroupNoComponents =
-        Group.builder()
-            .id("composite-group-id")
-            .scoring(MeasureScoring.COMPOSITE.toString())
-            .components(new ArrayList<>())
-            .build();
-
-    MeasureMetaData compositeMeasureMetaData =
-        draftMeasureMetaData.toBuilder().composite(true).build();
-
-    Measure existingMeasure =
-        measure1.toBuilder()
-            .active(true)
-            .measureSet(MeasureSet.builder().owner(username).build())
-            .measureMetaData(compositeMeasureMetaData)
-            .groups(new ArrayList<>(List.of(compositeGroupNoComponents)))
-            .build();
-
-    // When
-    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
-    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
-    when(actionLogService.logAction(
-            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
-        .thenReturn(true);
-    when(measureLockService.unlockMeasure(anyString(), anyString()))
-        .thenReturn(LockInfo.builder().build());
-
-    // Then
-    measureService.deactivateMeasure(existingMeasure.getId(), username);
-
-    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
-  }
-
-  @Test
-  public void testDeactivateNonCompositeMeasureDoesNotDelegate() {
-    // Given
-    String username = "test-user";
-
-    Measure existingMeasure =
-        measure1.toBuilder()
-            .active(true)
-            .measureSet(MeasureSet.builder().owner(username).build())
-            .measureMetaData(draftMeasureMetaData)
-            .build();
-
-    // When
-    when(measureService.findMeasureById(existingMeasure.getId())).thenReturn(existingMeasure);
-    when(measureRepository.save(any(Measure.class))).thenReturn(existingMeasure);
-    when(actionLogService.logAction(
-            existingMeasure.getId(), Measure.class, ActionType.DELETED, username))
-        .thenReturn(true);
-    when(measureLockService.unlockMeasure(anyString(), anyString()))
-        .thenReturn(LockInfo.builder().build());
-
-    // Then
-    measureService.deactivateMeasure(existingMeasure.getId(), username);
-
-    verify(compositeRelationshipService, times(0)).syncComponents(any(), any(), any(), anyString());
+    verify(compositeRelationshipService).removeCompositeRelationships(existingMeasure, username);
   }
 
   @Test


### PR DESCRIPTION
## MADiE PR

- deactivateMeasure: bypass owner check for MADIE-ADMIN (forward Authorization header)
- permDeleteMeasure: detach composite from its components before permanent delete
- extract shared CompositeRelationshipService.removeCompositeRelationships helper

Jira Ticket: [MAT-9811](https://jira.cms.gov/browse/MAT-9811)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
